### PR TITLE
Remove error when evaluating cpackget location

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -191,10 +191,9 @@ func (b Builder) getInternalVars() (vars InternalVars, err error) {
 		return vars, err
 	}
 
-	vars.cpackgetBin = filepath.Join(vars.binPath, "cpackget"+binExtension)
-	if _, err := os.Stat(vars.cpackgetBin); os.IsNotExist(err) {
-		log.Error("cpackget was not found")
-		return vars, err
+	cpackgetBin := filepath.Join(vars.binPath, "cpackget"+binExtension)
+	if _, err := os.Stat(cpackgetBin); !os.IsNotExist(err) {
+		vars.cpackgetBin = cpackgetBin
 	}
 
 	vars.xmllintBin, _ = exec.LookPath("xmllint")


### PR DESCRIPTION
Remove error when evaluating cpackget location since its presence is not mandatory.
Issue [#2](https://github.com/Open-CMSIS-Pack/cbuild/issues/2)