### PR TITLE
Add --rebuild and --packs options

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
   test:
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-latest, windows-latest, macos-latest]
         go: [1.18.x]
     name: '${{ matrix.platform }} | ${{ matrix.go }}'
     runs-on: ${{ matrix.platform }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,8 +10,15 @@ linters:
   enable:
     - deadcode
     - errcheck
+    - gosimple
     - govet
     - ineffassign
+    - staticcheck
+    - structcheck
     - typecheck
+    - unused
     - varcheck
+    - bodyclose
+    - stylecheck
     - gosec
+    - goimports

--- a/cmd/cbuild/root.go
+++ b/cmd/cbuild/root.go
@@ -72,7 +72,7 @@ func NewRootCmd() *cobra.Command {
 				return err
 			}
 
-			log.Info("cbuild: Build Invocation " + version + " (C) 2022 ARM")
+			log.Info("Build Invocation " + version + " (C) 2022 ARM")
 
 			intDir, _ := cmd.Flags().GetString("intdir")
 			outDir, _ := cmd.Flags().GetString("outdir")
@@ -85,6 +85,8 @@ func NewRootCmd() *cobra.Command {
 			debug, _ := cmd.Flags().GetBool("debug")
 			clean, _ := cmd.Flags().GetBool("clean")
 			schema, _ := cmd.Flags().GetBool("schema")
+			packs, _ := cmd.Flags().GetBool("packs")
+			rebuild, _ := cmd.Flags().GetBool("rebuild")
 
 			b := builder.Builder{
 				Runner:   utils.Runner{},
@@ -101,6 +103,8 @@ func NewRootCmd() *cobra.Command {
 					Debug:     debug,
 					Clean:     clean,
 					Schema:    schema,
+					Packs:     packs,
+					Rebuild:   rebuild,
 				},
 			}
 			err := b.Build()
@@ -116,9 +120,11 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.Flags().BoolP("debug", "d", false, "Enable debug messages")
 	rootCmd.Flags().BoolP("clean", "c", false, "Remove intermediate and output directories")
 	rootCmd.Flags().BoolP("schema", "s", false, "Check *.cprj file against CPRJ.xsd schema")
-	rootCmd.Flags().StringP("intdir", "i", "", "Set intermediate directory")
-	rootCmd.Flags().StringP("outdir", "o", "", "Set output directory")
-	rootCmd.Flags().StringP("update", "u", "", "Generate cprj file for reproducing current build")
+	rootCmd.Flags().BoolP("packs", "p", false, "Download missing software packs with cpackget")
+	rootCmd.Flags().BoolP("rebuild", "r", false, "Remove intermediate and output directories and rebuild")
+	rootCmd.Flags().StringP("intdir", "i", "", "Set directory for intermediate files")
+	rootCmd.Flags().StringP("outdir", "o", "", "Set directory for output files")
+	rootCmd.Flags().StringP("update", "u", "", "Generate *.cprj file for reproducing current build")
 	rootCmd.Flags().StringP("log", "l", "", "Save output messages in a log file")
 	rootCmd.Flags().StringP("generator", "g", "Ninja", "Select build system generator")
 	rootCmd.Flags().IntP("jobs", "j", 0, "Number of job slots for parallel execution")

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -291,6 +291,18 @@ func TestBuild(t *testing.T) {
 		assert.Nil(err)
 	})
 
+	t.Run("test build cprj with packs", func(t *testing.T) {
+		b.Options.Packs = true
+		err := b.Build()
+		assert.Nil(err)
+	})
+
+	t.Run("test rebuild cprj", func(t *testing.T) {
+		b.Options.Rebuild = true
+		err := b.Build()
+		assert.Nil(err)
+	})
+
 	t.Run("test build lock file", func(t *testing.T) {
 		b.Options.LockFile = testRoot + "/run/lockfile.cprj"
 		err := b.Build()


### PR DESCRIPTION
- Fixes the second issue described in https://github.com/Open-CMSIS-Pack/devtools/issues/374
- Introduces the `--packs` option for enabling the download of missing packs with cpackget
- Introduces the `--rebuild` option (clean + build) which seems to be the expectation in https://github.com/Open-CMSIS-Pack/cbuild/issues/5.