### PR TITLE
Updated go version to 1.19.3 and added vulnerability check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,20 +2,24 @@ name: Build
 
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        go: [1.18.x]
+        go: [1.19.3]
     name: '${{ matrix.platform }} | ${{ matrix.go }}'
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
-      - name: Install go 1.18
-        uses: actions/setup-go@v2
+      - name: Install go 1.19
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,20 @@ on:
     tags:
       - "v*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Go 1.18
-        uses: actions/setup-go@v2
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19.3
       - name: Generate release notes
         run: |
           git fetch --unshallow

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,6 @@ jobs:
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Detect vulnerability
         run: |
-          govulncheck ./...
           test -n "$(govulncheck ./... | grep 'No vulnerabilities found.')"
 
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: Test
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint
@@ -22,30 +26,51 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        go: [1.18.x]
+        go: [1.19.3]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
-      - name: Install go 1.18
-        uses: actions/setup-go@v2
+      - name: Install go 1.19
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
       - name: Check formatting
         run: |
           make format-check
 
+  vulnerability-check:
+    name: "Vulnerability check"
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+        go: [1.19.3]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install go 1.19
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Detect vulnerability
+        run: |
+          govulncheck ./...
+          test -n "$(govulncheck ./... | grep 'No vulnerabilities found.')"
+
   test:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        go: [1.18.x]
+        go: [1.19.3]
     name: '${{ matrix.platform }} | ${{ matrix.go }}'
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
-      - name: Install go 1.18
+      - name: Install go 1.19
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}


### PR DESCRIPTION
The change includes:

- Go version updated to 1.19.3
- Added vulnerability check
- Added concurrency options (This should stop the obsolete and redundant jobs from the same parent and save computational hours) 