### PR TITLE
Fix: cbuild throws error with project having no buildType

### DIFF
--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -24,6 +24,208 @@ type CSolutionBuilder struct {
 	builder.BuilderParams
 }
 
+func (b CSolutionBuilder) formulateArgs(command []string) (args []string, err error) {
+	if b.Options.Context != "" && b.Options.Configuration != "" {
+		err = errors.New("options '--context' and '--configuration' cannot be used together")
+		return
+	}
+
+	// formulate csolution arguments
+	args = append(args, command...)
+
+	if b.InputFile != "" {
+		args = append(args, "--solution="+b.InputFile)
+	}
+	if b.Options.Output != "" {
+		args = append(args, "--output="+b.Options.Output)
+	}
+	if b.Options.Load != "" {
+		args = append(args, "--load="+b.Options.Load)
+	}
+	if !b.Options.Schema {
+		args = append(args, "--no-check-schema")
+	}
+	if !b.Options.UpdateRte {
+		args = append(args, "--no-update-rte")
+	}
+	if b.Options.Configuration != "" {
+		args = append(args, "--context=*"+b.Options.Configuration)
+	}
+	if b.Options.Context != "" {
+		args = append(args, "--context="+b.Options.Context)
+	}
+	if b.Options.Filter != "" {
+		args = append(args, "--filter="+b.Options.Filter)
+	}
+	if b.Options.Verbose {
+		args = append(args, "--verbose")
+	}
+
+	return
+}
+
+func (b CSolutionBuilder) runCSolution(args []string, quite bool) (output string, err error) {
+	csolutionBin, err := b.getCSolutionPath()
+	if err != nil {
+		return
+	}
+
+	// run csolution with args
+	output, err = b.Runner.ExecuteCommand(csolutionBin, quite, args...)
+	if err != nil {
+		log.Error(err)
+	}
+	return
+}
+
+func (b CSolutionBuilder) installMissingPacks() (err error) {
+	args, err := b.formulateArgs([]string{"list", "packs"})
+	if err != nil {
+		log.Error("error in getting list of missing packs")
+		return
+	}
+	args = append(args, "-m")
+
+	// Get list of missing packs
+	output, err := b.runCSolution(args, false)
+	if err != nil {
+		log.Error("error in getting list of missing packs")
+		return err
+	}
+
+	// Installing missing packs
+	missingPacks := strings.Split(strings.ReplaceAll(strings.TrimSpace(output), "\r\n", "\n"), "\n")
+	for _, pack := range missingPacks {
+		pack = strings.ReplaceAll(pack, " ", "")
+		if pack == "" {
+			continue
+		}
+		args = []string{"pack", "add", pack, "--force-reinstall", "--agree-embedded-license"}
+		cpackgetBin := filepath.Join(b.InstallConfigs.BinPath, "cpackget"+b.InstallConfigs.BinExtn)
+		if _, err := os.Stat(cpackgetBin); os.IsNotExist(err) {
+			log.Error("cpackget was not found")
+			return err
+		}
+
+		_, err = b.Runner.ExecuteCommand(cpackgetBin, false, args...)
+		if err != nil {
+			log.Error("error installing pack : " + pack)
+			return err
+		}
+	}
+	return nil
+}
+
+func (b CSolutionBuilder) getCprjFilePath(idxFile string, context string) (string, error) {
+	var cprjPath string
+	data, err := utils.ParseCbuildIndexFile(idxFile)
+	if err == nil {
+		var path string
+		for _, cbuild := range data.BuildIdx.Cbuilds {
+			if strings.Contains(cbuild.Cbuild, context) {
+				path = cbuild.Cbuild
+				break
+			}
+		}
+		if path == "" {
+			err = errors.New("cprj file path not found")
+		} else {
+			cprjPath = filepath.Dir(idxFile) + "/" + filepath.Dir(path) + "/" + context + ".cprj"
+		}
+	}
+	return cprjPath, err
+}
+
+func (b CSolutionBuilder) getCSolutionPath() (path string, err error) {
+	path = filepath.Join(b.InstallConfigs.BinPath, "csolution"+b.InstallConfigs.BinExtn)
+	if _, err = os.Stat(path); os.IsNotExist(err) {
+		log.Error("error csolution was not found: \"" + err.Error() + "\"")
+	}
+	return
+}
+
+func (b CSolutionBuilder) validateContext(allContexts []string, inputContext string) (context string, err error) {
+	contextItem, err := utils.ParseContext(inputContext)
+	if err != nil {
+		return
+	}
+
+	context, err = utils.CreateContext(contextItem)
+	if err != nil {
+		return
+	}
+	if !utils.Contains(allContexts, context) {
+		sort.Strings(allContexts)
+		err = errors.New("specified context '" + inputContext +
+			"' not found. One of the following contexts must be specified:\n" +
+			strings.Join(allContexts, "\n"))
+	}
+	return
+}
+
+func (b CSolutionBuilder) processContext(context string) (err error) {
+	var formulatePath = func(cprjFilePath string, dir string, context utils.ContextItem) string {
+		path := filepath.Join(filepath.Dir(cprjFilePath), dir, context.ProjectName)
+		if context.BuildType != "" {
+			path = filepath.Join(path, context.BuildType)
+		}
+		path = filepath.Join(path, context.TargetType)
+		return path
+	}
+
+	infoMsg := "Processing context: \"" + context + "\""
+	fmt.Println(strings.Repeat("=", len(infoMsg)+13))
+	log.Info(infoMsg)
+
+	// if --output is used, ignore provided --outdir and --intdir
+	if b.Options.Output != "" && (b.Options.OutDir != "" || b.Options.IntDir != "") {
+		log.Warn("output files are generated under: \"" +
+			b.Options.Output + "\". Options --outdir and --intdir shall be ignored.")
+	}
+
+	// get project name from file name
+	nameTokens := strings.Split(filepath.Base(b.InputFile), ".")
+	if len(nameTokens) != 3 {
+		return errors.New("invalid csolution file name")
+	}
+
+	// get generated CPRJ file path from index yml
+	outputDir := b.Options.Output
+	if outputDir == "" {
+		outputDir = filepath.Dir(b.InputFile)
+	}
+	cprjFile, err := b.getCprjFilePath(
+		filepath.Join(outputDir, nameTokens[0]+".cbuild-idx.yml"), context)
+	if err != nil {
+		log.Error("error getting cprj file: " + err.Error())
+		return err
+	}
+
+	// formulate outdir & intdir path
+	selectedContext, _ := utils.ParseContext(context)
+	cprjBuildOptions := b.Options
+	cprjBuildOptions.OutDir = formulatePath(cprjFile, "out", selectedContext)
+	cprjBuildOptions.IntDir = formulatePath(cprjFile, "tmp", selectedContext)
+
+	log.Debug("outdir: " + b.Options.OutDir)
+	log.Debug("intdir: " + b.Options.IntDir)
+
+	// process generated CPRJ project
+	cprjBuilder := cproject.CprjBuilder{
+		BuilderParams: builder.BuilderParams{
+			Runner:         b.Runner,
+			Options:        cprjBuildOptions,
+			InputFile:      cprjFile,
+			InstallConfigs: b.InstallConfigs,
+		},
+	}
+	err = cprjBuilder.Build()
+	if err != nil {
+		log.Error("error processing '" + cprjFile + "'")
+	}
+	return
+}
+
 func (b CSolutionBuilder) listConfigurations() (configurations []string, err error) {
 	filter := b.Options.Filter
 	b.Options.Filter = ""
@@ -67,30 +269,21 @@ func (b CSolutionBuilder) listConfigurations() (configurations []string, err err
 }
 
 func (b CSolutionBuilder) listContexts(quite bool, ymlOrder bool) (contexts []string, err error) {
-	args := []string{"list", "contexts", "--solution=" + b.InputFile}
-
-	if b.Options.Filter != "" {
-		args = append(args, "--filter="+b.Options.Filter)
-	}
-
-	if !b.Options.Schema {
-		args = append(args, "--no-check-schema")
+	args, err := b.formulateArgs([]string{"list", "contexts"})
+	if err != nil {
+		return
 	}
 
 	if ymlOrder {
 		args = append(args, "--yml-order")
 	}
 
-	csolutionBin, err := b.getCsolutionPath()
+	output, err := b.runCSolution(args, quite)
 	if err != nil {
+		log.Error("error executing 'cbuild list contexts'")
 		return
 	}
 
-	output, err := b.Runner.ExecuteCommand(csolutionBin, quite, args...)
-	if err != nil {
-		log.Error("error executing 'cbuild list contexts'")
-		return nil, err
-	}
 	output = strings.ReplaceAll(output, " ", "")
 	if output != "" {
 		contexts = strings.Split(strings.ReplaceAll(strings.TrimSpace(output), "\r\n", "\n"), "\n")
@@ -99,69 +292,22 @@ func (b CSolutionBuilder) listContexts(quite bool, ymlOrder bool) (contexts []st
 }
 
 func (b CSolutionBuilder) listToolchains(quite bool) (toolchains []string, err error) {
-	csolutionBin, err := b.getCsolutionPath()
+	args, err := b.formulateArgs([]string{"list", "toolchains"})
 	if err != nil {
 		return
 	}
 
-	args := []string{"list", "toolchains"}
-	if b.InputFile != "" {
-		args = append(args, "--solution="+b.InputFile)
-	}
-
-	output, err := b.Runner.ExecuteCommand(csolutionBin, quite, args...)
+	output, err := b.runCSolution(args, quite)
 	if err != nil {
 		log.Error("error executing 'cbuild list toolchains'")
-		return toolchains, err
+		return
 	}
+
 	output = strings.ReplaceAll(output, " ", "")
 	if output != "" {
 		toolchains = strings.Split(strings.ReplaceAll(strings.TrimSpace(output), "\r\n", "\n"), "\n")
 	}
 	return toolchains, nil
-}
-
-func (b CSolutionBuilder) installMissingPacks() (err error) {
-	args := []string{"list", "packs", "--solution=" + b.InputFile, "-m",
-		"--context=" + b.Options.Context, "--filter=" + b.Options.Filter}
-
-	if !b.Options.Schema {
-		args = append(args, "--no-check-schema")
-	}
-
-	csolutionBin, err := b.getCsolutionPath()
-	if err != nil {
-		return
-	}
-
-	// Get list of missing packs
-	output, err := b.Runner.ExecuteCommand(csolutionBin, false, args...)
-	if err != nil {
-		log.Error("error in getting list of missing packs")
-		return err
-	}
-
-	// Installing missing packs
-	missingPacks := strings.Split(strings.ReplaceAll(strings.TrimSpace(output), "\r\n", "\n"), "\n")
-	for _, pack := range missingPacks {
-		pack = strings.ReplaceAll(pack, " ", "")
-		if pack == "" {
-			continue
-		}
-		args = []string{"pack", "add", pack, "--force-reinstall", "--agree-embedded-license"}
-		cpackgetBin := filepath.Join(b.InstallConfigs.BinPath, "cpackget"+b.InstallConfigs.BinExtn)
-		if _, err := os.Stat(cpackgetBin); os.IsNotExist(err) {
-			log.Error("cpackget was not found")
-			return err
-		}
-
-		_, err = b.Runner.ExecuteCommand(cpackgetBin, false, args...)
-		if err != nil {
-			log.Error("error installing pack : " + pack)
-			return err
-		}
-	}
-	return nil
 }
 
 func (b CSolutionBuilder) ListConfigurations() error {
@@ -183,60 +329,8 @@ func (b CSolutionBuilder) ListToolchains() error {
 	return err
 }
 
-func (b CSolutionBuilder) getCprjFilePath(idxFile string, context string) (string, error) {
-	var cprjPath string
-	data, err := utils.ParseCbuildIndexFile(idxFile)
-	if err == nil {
-		var path string
-		for _, cbuild := range data.BuildIdx.Cbuilds {
-			if strings.Contains(cbuild.Cbuild, context) {
-				path = cbuild.Cbuild
-				break
-			}
-		}
-		if path == "" {
-			err = errors.New("cprj file path not found")
-		} else {
-			cprjPath = filepath.Dir(idxFile) + "/" + filepath.Dir(path) + "/" + context + ".cprj"
-		}
-	}
-	return cprjPath, err
-}
-
-func (b CSolutionBuilder) getCsolutionPath() (path string, err error) {
-	path = filepath.Join(b.InstallConfigs.BinPath, "csolution"+b.InstallConfigs.BinExtn)
-	if _, err = os.Stat(path); os.IsNotExist(err) {
-		log.Error("error csolution was not found: \"" + err.Error() + "\"")
-	}
-	return
-}
-
-func (b CSolutionBuilder) validateContext(allContexts []string) (err error) {
-	_, err = utils.ParseContext(b.Options.Context)
-	if err != nil {
-		return
-	}
-
-	if !utils.Contains(allContexts, b.Options.Context) {
-		sort.Strings(allContexts)
-		err = errors.New("specified context '" + b.Options.Context +
-			"' not found. One of the following contexts must be specified:\n" +
-			strings.Join(allContexts, "\n"))
-	}
-	return
-}
-
 func (b CSolutionBuilder) Build() (err error) {
 	_ = utils.UpdateEnvVars(b.InstallConfigs.BinPath, b.InstallConfigs.EtcPath)
-	csolutionBin, err := b.getCsolutionPath()
-	if err != nil {
-		return
-	}
-
-	if b.Options.Context != "" && b.Options.Configuration != "" {
-		err = errors.New("options '--context' and '--configuration' cannot be used together")
-		return
-	}
 
 	// get yml ordered list of all contexts
 	allContexts, err := b.listContexts(true, true)
@@ -245,12 +339,16 @@ func (b CSolutionBuilder) Build() (err error) {
 		return
 	}
 
+	// get list of contexts needs to be processed
 	var selectedContexts []string
 	if b.Options.Context != "" {
-		if err = b.validateContext(allContexts); err != nil {
+		var context string
+		context, err = b.validateContext(allContexts, b.Options.Context)
+		if err != nil {
 			return
 		}
-		selectedContexts = append(selectedContexts, b.Options.Context)
+		b.Options.Context = context
+		selectedContexts = append(selectedContexts, context)
 	} else {
 		if b.Options.Configuration == "" {
 			// build all contexts when configuration is empty
@@ -264,6 +362,11 @@ func (b CSolutionBuilder) Build() (err error) {
 		}
 	}
 
+	args, err := b.formulateArgs([]string{"convert"})
+	if err != nil {
+		return
+	}
+
 	// install missing packs when --pack option is specified
 	if b.Options.Packs {
 		if err = b.installMissingPacks(); err != nil {
@@ -272,99 +375,18 @@ func (b CSolutionBuilder) Build() (err error) {
 		}
 	}
 
-	nameTokens := strings.Split(filepath.Base(b.InputFile), ".")
-	if len(nameTokens) != 3 {
-		return errors.New("invalid csolution file name")
-	}
-
-	var formulatePath = func(cprjFilePath string, dir string, context utils.ContextItem) string {
-		path := filepath.Join(filepath.Dir(cprjFilePath), dir, context.ProjectName)
-		if context.BuildType != "" {
-			path = filepath.Join(path, context.BuildType)
-		}
-		path = filepath.Join(path, context.TargetType)
-		return path
-	}
-
-	// formulate csolution arguments
-	args := []string{"convert", "--solution=" + b.InputFile}
-	if b.Options.Output != "" {
-		args = append(args, "--output="+b.Options.Output)
-	}
-	if b.Options.Load != "" {
-		args = append(args, "--load="+b.Options.Load)
-	}
-	if !b.Options.Schema {
-		args = append(args, "--no-check-schema")
-	}
-	if !b.Options.UpdateRte {
-		args = append(args, "--no-update-rte")
-	}
-	if b.Options.Configuration != "" {
-		configurationItem, err := utils.ParseConfiguration(b.Options.Configuration)
-		if err != nil {
-			return err
-		}
-		contextQuery := "*" + utils.CreateConfiguration(configurationItem)
-		if configurationItem.TargetType == "" {
-			contextQuery += "*"
-		}
-		args = append(args, "--context="+contextQuery)
-	}
-	if b.Options.Context != "" {
-		args = append(args, "--context="+b.Options.Context)
-	}
-
 	// step1: generate cprj files
-	_, err = b.Runner.ExecuteCommand(csolutionBin, false, args...)
+	_, err = b.runCSolution(args, false)
 	if err != nil {
 		log.Error(err)
 		return err
 	}
 
-	// build each selected context
+	// step2: process each selected context
 	for _, context := range selectedContexts {
-		infoMsg := "Building context: \"" + context + "\""
-		separator := strings.Repeat("=", len(infoMsg)+13)
-		log.Info(infoMsg + "\n" + separator)
-
-		// if --output is used, ignore provided --outdir and --intdir
-		if b.Options.Output != "" && (b.Options.OutDir != "" || b.Options.IntDir != "") {
-			log.Warn("output files are generated under: \"" + b.Options.Output + "\". Options --outdir and --intdir shall be ignored.")
-		}
-
-		// step2: get generated CPRJ file path from index yml
-		outputDir := b.Options.Output
-		if outputDir == "" {
-			outputDir = filepath.Dir(b.InputFile)
-		}
-		cprjFile, err := b.getCprjFilePath(
-			filepath.Join(outputDir, nameTokens[0]+".cbuild-idx.yml"), context)
+		err = b.processContext(context)
 		if err != nil {
-			log.Error("error getting cprj file: " + err.Error())
-			return err
-		}
-
-		// step3: formulate outdir & intdir path
-		selectedContext, _ := utils.ParseContext(context)
-		cprjBuildOptions := b.Options
-		cprjBuildOptions.OutDir = formulatePath(cprjFile, "out", selectedContext)
-		cprjBuildOptions.IntDir = formulatePath(cprjFile, "tmp", selectedContext)
-
-		log.Debug("outdir: " + b.Options.OutDir)
-		log.Debug("intdir: " + b.Options.IntDir)
-
-		// step4: build generated CPRJ project
-		cprjBuilder := cproject.CprjBuilder{
-			BuilderParams: builder.BuilderParams{
-				Runner:         b.Runner,
-				Options:        cprjBuildOptions,
-				InputFile:      cprjFile,
-				InstallConfigs: b.InstallConfigs,
-			},
-		}
-		if err = cprjBuilder.Build(); err != nil {
-			log.Error("error building '" + cprjFile + "'")
+			log.Error(err)
 			break
 		}
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -114,17 +114,15 @@ func ParseContext(context string) (item ContextItem, err error) {
 	targetIdx := strings.Index(context, "+")
 	buildIdx := strings.Index(context, ".")
 
-	if targetIdx == -1 && buildIdx == -1 {
-		// context with only projectName
-		projectName = context
-	} else if targetIdx != -1 && buildIdx == -1 {
+	if targetIdx == -1 || targetIdx < buildIdx {
+		err = parseError
+		return
+	}
+
+	if buildIdx == -1 {
 		// context with only projectName+targetType
 		projectName = context[:targetIdx]
 		targetType = context[targetIdx+1:]
-	} else if targetIdx == -1 && buildIdx != -1 {
-		// context with only projectName.buildType
-		projectName = context[:buildIdx]
-		buildType = context[buildIdx+1:]
 	} else {
 		// fully specified contexts
 		part := context[:targetIdx]
@@ -148,13 +146,26 @@ func ParseContext(context string) (item ContextItem, err error) {
 		}
 	}
 
-	if projectName == "" {
+	if projectName == "" || targetType == "" {
 		err = parseError
 		return
 	}
 	item.ProjectName = projectName
 	item.BuildType = buildType
 	item.TargetType = targetType
+	return
+}
+
+func CreateContext(contextItem ContextItem) (context string, err error) {
+	if contextItem.ProjectName == "" || contextItem.TargetType == "" {
+		err = errors.New("invalid input context item")
+		return
+	}
+	context = contextItem.ProjectName
+	if contextItem.BuildType != "" {
+		context += "." + contextItem.BuildType
+	}
+	context += "+" + contextItem.TargetType
 	return
 }
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -80,9 +80,9 @@ func TestParseContext(t *testing.T) {
 		{".Build", true, ContextItem{}},
 		{".Build+Target", true, ContextItem{}},
 		{"+Target.Build", true, ContextItem{}},
-		{"Project", true, ContextItem{}},
-		{"Project.Build", true, ContextItem{}},
-		{"Project+Target", true, ContextItem{}},
+		{"Project", false, ContextItem{ProjectName: "Project", BuildType: "", TargetType: ""}},
+		{"Project.Build", false, ContextItem{ProjectName: "Project", BuildType: "Build", TargetType: ""}},
+		{"Project+Target", false, ContextItem{ProjectName: "Project", BuildType: "", TargetType: "Target"}},
 		{"Project.Build+Target", false, ContextItem{ProjectName: "Project", BuildType: "Build", TargetType: "Target"}},
 		{"Project+Target.Build", false, ContextItem{ProjectName: "Project", BuildType: "Build", TargetType: "Target"}},
 	}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -70,6 +70,7 @@ func TestParseContext(t *testing.T) {
 		ExpectError     bool
 		ExpectedContext ContextItem
 	}{
+		// negative test cases
 		{"", true, ContextItem{}},
 		{".+", true, ContextItem{}},
 		{".Build+", true, ContextItem{}},
@@ -80,11 +81,15 @@ func TestParseContext(t *testing.T) {
 		{".Build", true, ContextItem{}},
 		{".Build+Target", true, ContextItem{}},
 		{"+Target.Build", true, ContextItem{}},
-		{"Project", false, ContextItem{ProjectName: "Project", BuildType: "", TargetType: ""}},
-		{"Project.Build", false, ContextItem{ProjectName: "Project", BuildType: "Build", TargetType: ""}},
+		{"Project", true, ContextItem{}},
+		{"Project.Build", true, ContextItem{}},
+		{"Project.Build+", true, ContextItem{}},
+		{"Project+Target.Build", true, ContextItem{}},
+
+		// positive test cases
+		{"Project.+Target", false, ContextItem{ProjectName: "Project", BuildType: "", TargetType: "Target"}},
 		{"Project+Target", false, ContextItem{ProjectName: "Project", BuildType: "", TargetType: "Target"}},
 		{"Project.Build+Target", false, ContextItem{ProjectName: "Project", BuildType: "Build", TargetType: "Target"}},
-		{"Project+Target.Build", false, ContextItem{ProjectName: "Project", BuildType: "Build", TargetType: "Target"}},
 	}
 	for _, test := range testCases {
 		contextItem, err := ParseContext(test.Input)
@@ -96,6 +101,31 @@ func TestParseContext(t *testing.T) {
 		assert.Equal(contextItem.ProjectName, test.ExpectedContext.ProjectName)
 		assert.Equal(contextItem.BuildType, test.ExpectedContext.BuildType)
 		assert.Equal(contextItem.TargetType, test.ExpectedContext.TargetType)
+	}
+}
+
+func TestCreateContext(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		Input          ContextItem
+		ExpectError    bool
+		ExpectedOutput string
+	}{
+		{ContextItem{ProjectName: "", BuildType: "", TargetType: ""}, true, ""},
+		{ContextItem{ProjectName: "", BuildType: "Build", TargetType: "Target"}, true, ""},
+		{ContextItem{ProjectName: "Project", BuildType: "Build", TargetType: ""}, true, ""},
+		{ContextItem{ProjectName: "Project", BuildType: "", TargetType: "Target"}, false, "Project+Target"},
+		{ContextItem{ProjectName: "Project", BuildType: "Build", TargetType: "Target"}, false, "Project.Build+Target"},
+	}
+	for _, test := range testCases {
+		context, err := CreateContext(test.Input)
+		if test.ExpectError {
+			assert.Error(err)
+		} else {
+			assert.Nil(err)
+		}
+		assert.Equal(context, test.ExpectedOutput)
 	}
 }
 


### PR DESCRIPTION
This change addresses the following:
- [Issue-46](https://github.com/Open-CMSIS-Pack/cbuild/issues/46)
- Code cleanup and restructuring
- stdout string changes
    - Changed `Building context` to `Processing context`
    - Moved line separator (======) above context info  
      ```
          ==================================================
          info cbuild: Processing context: "Hello.Debug+AVH"
      ```
