### PR TITLE
[cbuild] Add list environment command

### DIFF
--- a/cmd/cbuild/commands/list/list.go
+++ b/cmd/cbuild/commands/list/list.go
@@ -30,5 +30,10 @@ func init() {
 		_ = command.Flags().MarkHidden("toolchain")
 		command.Parent().HelpFunc()(command, strings)
 	})
-	ListCmd.AddCommand(ListConfigurationsCmd, ListContextsCmd, ListToolchainsCmd)
+	ListEnvironmentCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+		_ = command.Flags().MarkHidden("schema")
+		_ = command.Flags().MarkHidden("toolchain")
+		command.Parent().HelpFunc()(command, strings)
+	})
+	ListCmd.AddCommand(ListConfigurationsCmd, ListContextsCmd, ListToolchainsCmd, ListEnvironmentCmd)
 }

--- a/cmd/cbuild/commands/list/list_environment.go
+++ b/cmd/cbuild/commands/list/list_environment.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package list
+
+import (
+	"cbuild/pkg/builder"
+	"cbuild/pkg/builder/csolution"
+	"cbuild/pkg/utils"
+
+	"github.com/spf13/cobra"
+)
+
+var ListEnvironmentCmd = &cobra.Command{
+	Use:   "environment",
+	Short: "Print list of environment configurations",
+	Args:  cobra.MaximumNArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		configs, err := utils.GetInstallConfigs()
+		if err != nil {
+			return err
+		}
+
+		p := csolution.CSolutionBuilder{
+			BuilderParams: builder.BuilderParams{
+				Runner:         utils.Runner{},
+				InstallConfigs: configs,
+			},
+		}
+		return p.ListEnvironment()
+	},
+}

--- a/cmd/cbuild/commands/list/list_environment_test.go
+++ b/cmd/cbuild/commands/list/list_environment_test.go
@@ -8,7 +8,6 @@ package list_test
 
 import (
 	"cbuild/cmd/cbuild/commands"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,7 +15,6 @@ import (
 
 func TestListEnvironmentCommand(t *testing.T) {
 	assert := assert.New(t)
-	os.Setenv("CMSIS_BUILD_ROOT", testRoot+"/run/bin")
 
 	t.Run("invalid args", func(t *testing.T) {
 		cmd := commands.NewRootCmd()
@@ -34,7 +32,7 @@ func TestListEnvironmentCommand(t *testing.T) {
 
 	t.Run("test help", func(t *testing.T) {
 		cmd := commands.NewRootCmd()
-		cmd.SetArgs([]string{"list", "toolchains", "-h"})
+		cmd.SetArgs([]string{"list", "environment", "-h"})
 		err := cmd.Execute()
 		assert.Nil(err)
 	})

--- a/cmd/cbuild/commands/list/list_environment_test.go
+++ b/cmd/cbuild/commands/list/list_environment_test.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package list_test
+
+import (
+	"cbuild/cmd/cbuild/commands"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListEnvironmentCommand(t *testing.T) {
+	assert := assert.New(t)
+	os.Setenv("CMSIS_BUILD_ROOT", testRoot+"/run/bin")
+
+	t.Run("invalid args", func(t *testing.T) {
+		cmd := commands.NewRootCmd()
+		cmd.SetArgs([]string{"list", "environment", "--invalid"})
+		err := cmd.Execute()
+		assert.Error(err)
+	})
+
+	t.Run("test list environment", func(t *testing.T) {
+		cmd := commands.NewRootCmd()
+		cmd.SetArgs([]string{"list", "environment"})
+		err := cmd.Execute()
+		assert.Error(err)
+	})
+
+	t.Run("test help", func(t *testing.T) {
+		cmd := commands.NewRootCmd()
+		cmd.SetArgs([]string{"list", "toolchains", "-h"})
+		err := cmd.Execute()
+		assert.Nil(err)
+	})
+}

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -303,7 +303,7 @@ func (b CSolutionBuilder) listEnvironment(quiet bool) (envConfigs []string, err 
 		}
 
 		// run "exe --version" command
-		versionStr, err := b.Runner.ExecuteCommand(path, false, "--version")
+		versionStr, err := b.Runner.ExecuteCommand(path, true, "--version")
 		if err != nil {
 			versionStr = ""
 		}
@@ -368,12 +368,13 @@ func (b CSolutionBuilder) ListToolchains() error {
 
 func (b CSolutionBuilder) ListEnvironment() error {
 	envConfigs, err := b.listEnvironment(true)
-	if err == nil {
-		for _, config := range envConfigs {
-			fmt.Println(config)
-		}
+	if err != nil {
+		return err
 	}
-	return err
+	for _, config := range envConfigs {
+		fmt.Println(config)
+	}
+	return nil
 }
 
 func (b CSolutionBuilder) Build() (err error) {

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -295,8 +295,8 @@ func (b CSolutionBuilder) listToolchains(quiet bool) (toolchains []string, err e
 }
 
 func (b CSolutionBuilder) listEnvironment(quiet bool) (envConfigs []string, err error) {
-	// get installer path and version number
-	getInstallerInfo := func(name string) string {
+	// get installed exe path and version number
+	getInstalledExeInfo := func(name string) string {
 		path, err := utils.GetInstalledExePath(name)
 		if err != nil || path == "" {
 			return "<Not Found>"
@@ -341,8 +341,8 @@ func (b CSolutionBuilder) listEnvironment(quiet bool) (envConfigs []string, err 
 	}
 
 	// step2: add other environment info
-	envConfigs = append(envConfigs, "cmake="+getInstallerInfo("cmake"))
-	envConfigs = append(envConfigs, "ninja="+getInstallerInfo("ninja"))
+	envConfigs = append(envConfigs, "cmake="+getInstalledExeInfo("cmake"))
+	envConfigs = append(envConfigs, "ninja="+getInstalledExeInfo("ninja"))
 
 	return envConfigs, nil
 }

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -293,6 +294,59 @@ func (b CSolutionBuilder) listToolchains(quiet bool) (toolchains []string, err e
 	return toolchains, nil
 }
 
+func (b CSolutionBuilder) listEnvironment(quiet bool) (envConfigs []string, err error) {
+	// get installer path and version number
+	getInstallerInfo := func(name string) string {
+		path, err := utils.GetInstalledExePath(name)
+		if err != nil || path == "" {
+			return "<Not Found>"
+		}
+
+		// run "exe --version" command
+		versionStr, err := b.Runner.ExecuteCommand(path, false, "--version")
+		if err != nil {
+			versionStr = ""
+		}
+
+		// get version
+		var version string
+		if name == "cmake" {
+			regex := "version\\s(.*?)\\s"
+			re, err := regexp.Compile(regex)
+			if err == nil {
+				match := re.FindAllStringSubmatch(versionStr, 1)
+				for index := range match {
+					version = match[index][1]
+					break
+				}
+			}
+		} else {
+			version = versionStr
+		}
+		info := path
+		if version != "" {
+			info += ", version " + version
+		}
+		return info
+	}
+
+	// step1: call csolution list environment
+	args := []string{"list", "environment"}
+	output, err := b.runCSolution(args, quiet)
+	if err != nil {
+		return
+	}
+	if output != "" {
+		envConfigs = strings.Split(strings.ReplaceAll(strings.TrimSpace(output), "\r\n", "\n"), "\n")
+	}
+
+	// step2: add other environment info
+	envConfigs = append(envConfigs, "cmake="+getInstallerInfo("cmake"))
+	envConfigs = append(envConfigs, "ninja="+getInstallerInfo("ninja"))
+
+	return envConfigs, nil
+}
+
 func (b CSolutionBuilder) ListConfigurations() error {
 	configurations, err := b.listConfigurations()
 	if err != nil {
@@ -309,6 +363,16 @@ func (b CSolutionBuilder) ListContexts() error {
 
 func (b CSolutionBuilder) ListToolchains() error {
 	_, err := b.listToolchains(false)
+	return err
+}
+
+func (b CSolutionBuilder) ListEnvironment() error {
+	envConfigs, err := b.listEnvironment(true)
+	if err == nil {
+		for _, config := range envConfigs {
+			fmt.Println(config)
+		}
+	}
 	return err
 }
 

--- a/pkg/utils/configs.go
+++ b/pkg/utils/configs.go
@@ -7,11 +7,10 @@
 package utils
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
-
-	log "github.com/sirupsen/logrus"
 )
 
 type Configurations struct {
@@ -28,8 +27,7 @@ func GetInstallConfigs() (configs Configurations, err error) {
 	if binPath == "" {
 		binPath, err = GetExecutablePath()
 		if err != nil {
-			log.Error("executable path was not found")
-			return configs, err
+			return Configurations{}, err
 		}
 	}
 	if binPath != "" {
@@ -38,9 +36,9 @@ func GetInstallConfigs() (configs Configurations, err error) {
 
 	configs.BinPath = binPath
 	etcPath := filepath.Clean(binPath + "/../etc")
-	if _, err := os.Stat(etcPath); os.IsNotExist(err) {
-		log.Error("etc directory was not found")
-		return configs, err
+	if _, err = os.Stat(etcPath); os.IsNotExist(err) {
+		err = errors.New(etcPath + " path was not found")
+		return Configurations{}, err
 	}
 	if etcPath != "" {
 		etcPath, _ = filepath.Abs(etcPath)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -9,6 +9,7 @@ package utils
 import (
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -335,4 +336,12 @@ func Contains[T comparable](slice []T, elem T) bool {
 		}
 	}
 	return false
+}
+
+func GetInstalledExePath(exeName string) (path string, err error) {
+	path, err = exec.LookPath(exeName)
+	if strings.Contains(path, "\\") {
+		path = strings.ReplaceAll(path, "\\", "/")
+	}
+	return
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -302,3 +302,12 @@ func TestContains(t *testing.T) {
 		assert.Equal(output, test.expectedResult)
 	}
 }
+
+func TestGetInstalledExePath(t *testing.T) {
+	assert := assert.New(t)
+	t.Run("test to get invalid executable path", func(t *testing.T) {
+		path, err := GetInstalledExePath("testunknown")
+		assert.Equal(path, "")
+		assert.Error(err)
+	})
+}


### PR DESCRIPTION
Related to https://github.com/Open-CMSIS-Pack/devtools/issues/783

Extended `cbuild` with `list environment` command
for e.g
```
$ cbuild list environment
CMSIS_PACK_ROOT=C:/Users/Test/AppData/Local/Arm/Packs
CMSIS_COMPILER_ROOT=C:/Test/cmsis-toolbox/etc
cmake=C:/tools/bin/cmake.exe, version 3.26.0
ninja=C:/Users/Test/AppData/Local/Programs/Python/Python310/Scripts/ninja.exe, version 1.10.2
```
or 
```
$ cbuild list environment
CMSIS_PACK_ROOT=C:/Users/Test/AppData/Local/Arm/Packs
CMSIS_COMPILER_ROOT=C:/Test/cmsis-toolbox/etc
cmake=<Not Found>
ninja=<Not Found>
```
or
```
$ cbuild list environment -h
Print list of environment configurations

Usage:
  cbuild list environment [flags]

Flags:
  -h, --help   help for environment

Global Flags:
  -l, --log string   Save output messages in a log file

```