### PR TITLE
Print commands in debug mode

### DIFF
--- a/pkg/builder/cproject/builder.go
+++ b/pkg/builder/cproject/builder.go
@@ -256,9 +256,18 @@ func (b CprjBuilder) Build() error {
 		lockFile, _ := filepath.Abs(b.Options.LockFile)
 		args = append(args, "--update="+lockFile)
 	}
+
+	if b.Options.Debug {
+		log.Debug("cbuildgen command: " + vars.cbuildgenBin + " " + strings.Join(args, " "))
+	}
+
 	_, err = b.Runner.ExecuteCommand(vars.cbuildgenBin, false, args...)
 	if err != nil {
 		log.Error("error executing 'cbuildgen cmake'")
+		return err
+	}
+
+	if _, err := os.Stat(dirs.intDir + "/CMakeLists.txt"); errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 
@@ -281,6 +290,11 @@ func (b CprjBuilder) Build() error {
 	} else {
 		args = append(args, "-Wno-dev")
 	}
+
+	if b.Options.Debug {
+		log.Debug("cmake configuration command: " + vars.cmakeBin + " " + strings.Join(args, " "))
+	}
+
 	_, err = b.Runner.ExecuteCommand(vars.cmakeBin, b.Options.Quiet, args...)
 	if err != nil {
 		log.Error("error executing 'cmake' configuration")
@@ -294,6 +308,11 @@ func (b CprjBuilder) Build() error {
 	if b.Options.Debug || b.Options.Verbose {
 		args = append(args, "--verbose")
 	}
+
+	if b.Options.Debug {
+		log.Debug("cmake build command: " + vars.cmakeBin + " " + strings.Join(args, " "))
+	}
+
 	_, err = b.Runner.ExecuteCommand(vars.cmakeBin, false, args...)
 	if err != nil {
 		log.Error("error executing 'cmake' build")

--- a/pkg/builder/cproject/builder_test.go
+++ b/pkg/builder/cproject/builder_test.go
@@ -31,6 +31,10 @@ func (r RunnerMock) ExecuteCommand(program string, quiet bool, args ...string) (
 			packlistFile := testRoot + "/run/IntDir/minimal.cpinstall"
 			file, _ := os.Create(packlistFile)
 			defer file.Close()
+		} else if args[0] == "cmake" {
+			cmakelistFile := testRoot + "/run/IntDir/CMakeLists.txt"
+			file, _ := os.Create(cmakelistFile)
+			defer file.Close()
 		}
 	} else if strings.Contains(program, "cpackget") {
 	} else if strings.Contains(program, "cmake") {
@@ -328,8 +332,9 @@ func TestBuild(t *testing.T) {
 	})
 
 	t.Run("test build makefile generator", func(t *testing.T) {
-		b.Options.IntDir = testRoot + "/run/makefiles/IntDir"
-		b.Options.OutDir = testRoot + "/run/makefiles/OutDir"
+		b.Options.IntDir = testRoot + "/run/IntDir"
+		b.Options.OutDir = testRoot + "/run/OutDir"
+		b.Options.Debug = true
 		b.Options.Generator = "Unix Makefiles"
 		err := b.Build()
 		assert.Nil(err)


### PR DESCRIPTION
The change includes
- Printing `CMake `and `cbuildgen `commands in `--debug` mode. The commands should be listed as 
  - `debug cbuild: cbuildgen command: <COMMAND>`
  - `debug cbuild: cmake configuration command: <COMMAND>`
  - `debug cbuild: cmake build command: <COMMAND>`
- Checks the existence of `CMakelists.txt` file before running `cmake `commands
