### PR TITLE
CodeClimate configs

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,22 @@
+version: "2"
+checks:
+  argument-count:
+    enabled: false
+  complex-logic:
+    enabled: false
+  identical-code:
+    enabled: true
+  file-lines:
+    enabled: false
+  method-complexity:
+    enabled: false
+  method-count:
+    enabled: false
+  method-lines:
+    enabled: false
+  nested-control-flow:
+    enabled: false
+  return-statements:
+    enabled: false
+  similar-code:
+    enabled: true

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 [![Release](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/release.yml/badge.svg)](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/release.yml)
 [![Build](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/build.yml/badge.svg)](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/build.yml)
 [![Test](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/test.yml/badge.svg)](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/test.yml)
-[!TPIP Check](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/tpip-check.yml/badge.svg)](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/tpip-check.yml)
-[!Markdown](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/markdown.yml/badge.svg)](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/markdown.yml)
-[!Release](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/release.yml/badge.svg)](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/release.yml)
+[![TPIP Check](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/tpip-check.yml/badge.svg)](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/tpip-check.yml)
+[![Markdown](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/markdown.yml/badge.svg)](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/markdown.yml)
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/53904fe8cbd887f3d5b0/maintainability)](https://codeclimate.com/github/Open-CMSIS-Pack/cbuild/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/53904fe8cbd887f3d5b0/test_coverage)](https://codeclimate.com/github/Open-CMSIS-Pack/cbuild/test_coverage)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 [![Release](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/release.yml/badge.svg)](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/release.yml)
 [![Build](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/build.yml/badge.svg)](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/build.yml)
 [![Test](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/test.yml/badge.svg)](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/test.yml)
+[!TPIP Check](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/tpip-check.yml/badge.svg)](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/tpip-check.yml)
+[!Markdown](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/markdown.yml/badge.svg)](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/markdown.yml)
+[!Release](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/release.yml/badge.svg)](https://github.com/Open-CMSIS-Pack/cbuild/actions/workflows/release.yml)
+
+[![Maintainability](https://api.codeclimate.com/v1/badges/53904fe8cbd887f3d5b0/maintainability)](https://codeclimate.com/github/Open-CMSIS-Pack/cbuild/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/53904fe8cbd887f3d5b0/test_coverage)](https://codeclimate.com/github/Open-CMSIS-Pack/cbuild/test_coverage)
 
 # cbuild: Open-CMSIS-Pack Build Invocation Utility
 


### PR DESCRIPTION
Added badges and code climate configuration file.
Please note that currently only the identical and similar code scans are enabled. All style checks are disabled for the time being.