### PR TITLE
Adapt workflow for new download-artifact action changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           zip -r testreport.zip testreport
 
-      - name: Attach coverage report to release assets
+      - name: Attach test report to release assets
         if: startsWith(github.ref, 'refs/tags/')
         uses: svenstaro/upload-release-action@1beeb572c19a9242f4361f4cee78f8e0d9aec5df # v2
         with:
@@ -41,6 +41,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
 
       - name: Install Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
@@ -50,13 +52,12 @@ jobs:
 
       - name: Generate release notes
         run: |
-          git fetch --unshallow
           ./scripts/release_notes > /tmp/RELEASE_NOTES
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
           version: latest
-          args: release --clean --release-notes=/tmp/RELEASE_NOTES
+          args: release ${{ github.event_name != 'push' && '--snapshot' || '' }} --clean --release-notes=/tmp/RELEASE_NOTES
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,11 @@
 name: Release
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/release.yml
+      - ./scripts/release_notes
+      - .goreleaser.yml
   push:
     tags:
       - "v*"
@@ -15,10 +20,10 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - name: Download coverage report
+      - name: Download test results
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
-          name: test-results
+          pattern: test-results-*
           path: testreport/
 
       - name: Zip test reports
@@ -26,6 +31,7 @@ jobs:
           zip -r testreport.zip testreport
 
       - name: Attach coverage report to release assets
+        if: startsWith(github.ref, 'refs/tags/')
         uses: svenstaro/upload-release-action@1beeb572c19a9242f4361f4cee78f8e0d9aec5df # v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,6 @@ jobs:
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
           version: latest
-          args: release --rm-dist --release-notes=/tmp/RELEASE_NOTES
+          args: release --clean --release-notes=/tmp/RELEASE_NOTES
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
- Adapting workflow because the new version of download-artifact action has [breaking changes](https://github.com/actions/download-artifact?tab=readme-ov-file#breaking-changes).
- `--rm-dist` has been deprecated in favor of `--clean` [link](https://goreleaser.com/deprecations/#__tabbed_11_2)
- Added `pull_request `event to ensure operational workflow