### PR TITLE
Extend command line with setup command

### DIFF
--- a/cmd/cbuild/commands/root.go
+++ b/cmd/cbuild/commands/root.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Open-CMSIS-Pack/cbuild/v2/cmd/cbuild/commands/build"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/cmd/cbuild/commands/list"
+	"github.com/Open-CMSIS-Pack/cbuild/v2/cmd/cbuild/commands/setup"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder/cproject"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder/csolution"
@@ -221,7 +222,7 @@ func NewRootCmd() *cobra.Command {
 	_ = rootCmd.Flags().MarkHidden("update")
 
 	rootCmd.SetFlagErrorFunc(FlagErrorFunc)
-	rootCmd.AddCommand(build.BuildCPRJCmd, list.ListCmd)
+	rootCmd.AddCommand(build.BuildCPRJCmd, list.ListCmd, setup.SetUpCmd)
 	return rootCmd
 }
 

--- a/cmd/cbuild/commands/setup/setup.go
+++ b/cmd/cbuild/commands/setup/setup.go
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2024 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package setup
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+
+	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder"
+	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder/csolution"
+	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+func SetUpProject(cmd *cobra.Command, args []string) error {
+	var inputFile string
+	if len(args) == 1 {
+		inputFile = args[0]
+	} else {
+		_ = cmd.Help()
+		return errors.New("invalid arguments")
+	}
+
+	fileName := filepath.Base(inputFile)
+	if !strings.HasSuffix(fileName, ".csolution.yml") {
+		return errors.New("invalid file argument")
+	}
+
+	logFile, _ := cmd.Flags().GetString("log")
+	generator, _ := cmd.Flags().GetString("generator")
+	target, _ := cmd.Flags().GetString("target")
+	contexts, _ := cmd.Flags().GetStringSlice("context")
+	load, _ := cmd.Flags().GetString("load")
+	output, _ := cmd.Flags().GetString("output")
+	jobs, _ := cmd.Flags().GetInt("jobs")
+	quiet, _ := cmd.Flags().GetBool("quiet")
+	debug, _ := cmd.Flags().GetBool("debug")
+	verbose, _ := cmd.Flags().GetBool("verbose")
+	clean, _ := cmd.Flags().GetBool("clean")
+	schema, _ := cmd.Flags().GetBool("schema")
+	packs, _ := cmd.Flags().GetBool("packs")
+	rebuild, _ := cmd.Flags().GetBool("rebuild")
+	updateRte, _ := cmd.Flags().GetBool("update-rte")
+	toolchain, _ := cmd.Flags().GetString("toolchain")
+	useContextSet, _ := cmd.Flags().GetBool("context-set")
+	frozenPacks, _ := cmd.Flags().GetBool("frozen-packs")
+	useCbuild2CMake, _ := cmd.Flags().GetBool("cbuild2cmake")
+
+	options := builder.Options{
+		LogFile:         logFile,
+		Generator:       generator,
+		Target:          target,
+		Jobs:            jobs,
+		Quiet:           quiet,
+		Debug:           debug,
+		Verbose:         verbose,
+		Clean:           clean,
+		Schema:          schema,
+		Packs:           packs,
+		Rebuild:         rebuild,
+		UpdateRte:       updateRte,
+		Contexts:        contexts,
+		UseContextSet:   useContextSet,
+		Load:            load,
+		Output:          output,
+		Toolchain:       toolchain,
+		FrozenPacks:     frozenPacks,
+		UseCbuild2CMake: useCbuild2CMake,
+	}
+
+	configs, err := utils.GetInstallConfigs()
+	if err != nil {
+		return err
+	}
+
+	params := builder.BuilderParams{
+		Runner:         utils.Runner{},
+		Options:        options,
+		InputFile:      inputFile,
+		InstallConfigs: configs,
+		Setup:          true,
+	}
+
+	b := csolution.CSolutionBuilder{
+		BuilderParams: params,
+	}
+
+	return b.Build()
+}
+
+var SetUpCmd = &cobra.Command{
+	Use:   "setup <name>.csolution.yml [options]",
+	Short: "Initialize project",
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return SetUpProject(cmd, args)
+	},
+}
+
+func init() {
+	SetUpCmd.DisableFlagsInUseLine = true
+	SetUpCmd.Flags().BoolP("help", "h", false, "Print usage")
+	SetUpCmd.Flags().BoolP("quiet", "q", false, "Suppress output messages except build invocations")
+	SetUpCmd.Flags().BoolP("debug", "d", false, "Enable debug messages")
+	SetUpCmd.Flags().BoolP("verbose", "v", false, "Enable verbose messages from toolchain builds")
+	SetUpCmd.Flags().BoolP("clean", "C", false, "Remove intermediate and output directories")
+	SetUpCmd.Flags().BoolP("packs", "p", false, "Download missing software packs with cpackget")
+	SetUpCmd.Flags().BoolP("rebuild", "r", false, "Remove intermediate and output directories and rebuild")
+	SetUpCmd.Flags().BoolP("update-rte", "", false, "Update the RTE directory and files")
+	SetUpCmd.Flags().BoolP("context-set", "S", false, "Use context set")
+	SetUpCmd.Flags().BoolP("frozen-packs", "", false, "The list of packs from cbuild-pack.yml is frozen and raises error if not up-to-date")
+	SetUpCmd.Flags().StringP("generator", "g", "Ninja", "Select build system generator")
+	SetUpCmd.Flags().StringSliceP("context", "c", []string{}, "Input context names [<project-name>][.<build-type>][+<target-type>]")
+	SetUpCmd.Flags().StringP("load", "l", "", "Set policy for packs loading [latest | all | required]")
+	SetUpCmd.Flags().IntP("jobs", "j", 0, "Number of job slots for parallel execution")
+	SetUpCmd.Flags().StringP("target", "t", "", "Optional CMake target name")
+	SetUpCmd.Flags().StringP("output", "O", "", "Set directory for all output files")
+	SetUpCmd.Flags().BoolP("schema", "s", true, "Validate project input file(s) against schema")
+	SetUpCmd.Flags().StringP("log", "", "", "Save output messages in a log file")
+	SetUpCmd.Flags().StringP("toolchain", "", "", "Input toolchain to be used")
+	SetUpCmd.Flags().BoolP("cbuild2cmake", "", false, "Use cbuild2cmake")
+}

--- a/cmd/cbuild/commands/setup/setup_test.go
+++ b/cmd/cbuild/commands/setup/setup_test.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package setup_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Open-CMSIS-Pack/cbuild/v2/cmd/cbuild/commands"
+	"github.com/stretchr/testify/assert"
+)
+
+const testRoot = "../../../../test"
+const testDir = "command"
+
+func TestSetupCommand(t *testing.T) {
+	assert := assert.New(t)
+	csolutionFile := filepath.Join(testRoot, testDir, "TestSolution/test.csolution.yml")
+
+	t.Run("test valid command", func(t *testing.T) {
+		cmd := commands.NewRootCmd()
+		cmd.SetArgs([]string{"setup", csolutionFile})
+		err := cmd.Execute()
+		assert.Error(err)
+	})
+
+	t.Run("No arguments", func(t *testing.T) {
+		cmd := commands.NewRootCmd()
+		cmd.SetArgs([]string{"setup"})
+		err := cmd.Execute()
+		assert.Error(err)
+	})
+
+	t.Run("invalid flag", func(t *testing.T) {
+		cmd := commands.NewRootCmd()
+		cmd.SetArgs([]string{"setup", csolutionFile, "--invalid"})
+		err := cmd.Execute()
+		assert.Error(err)
+	})
+
+	t.Run("multiple arguments", func(t *testing.T) {
+		cmd := commands.NewRootCmd()
+		cmd.SetArgs([]string{"setup", csolutionFile, csolutionFile})
+		err := cmd.Execute()
+		assert.Error(err)
+	})
+
+	t.Run("test setup help", func(t *testing.T) {
+		cmd := commands.NewRootCmd()
+		cmd.SetArgs([]string{"setup", "-h"})
+		err := cmd.Execute()
+		assert.Nil(err)
+	})
+
+	t.Run("test setup invalid input argument", func(t *testing.T) {
+		cmd := commands.NewRootCmd()
+		cmd.SetArgs([]string{"setup", "test.cbuild.yml"})
+		err := cmd.Execute()
+		assert.Nil(err)
+	})
+}

--- a/pkg/builder/cproject/builder.go
+++ b/pkg/builder/cproject/builder.go
@@ -105,7 +105,6 @@ func (b CprjBuilder) getDirs() (dirs builder.BuildDirs, err error) {
 }
 
 func (b CprjBuilder) Build() error {
-
 	b.InputFile, _ = filepath.Abs(b.InputFile)
 	err := b.checkCprj()
 	if err != nil {
@@ -244,6 +243,11 @@ func (b CprjBuilder) Build() error {
 	}
 
 	args = []string{"--build", dirs.IntDir, "-j", fmt.Sprintf("%d", b.GetJobs())}
+
+	if b.Setup {
+		args = append(args, "--target", "database")
+	}
+
 	if b.Options.Target != "" {
 		args = append(args, "--target", b.Options.Target)
 	}
@@ -261,6 +265,10 @@ func (b CprjBuilder) Build() error {
 		return err
 	}
 
-	log.Info("build finished successfully!")
+	operation := "build"
+	if b.Setup {
+		operation = "set up"
+	}
+	log.Info(operation + " finished successfully!")
 	return nil
 }

--- a/pkg/builder/cproject/builder.go
+++ b/pkg/builder/cproject/builder.go
@@ -267,7 +267,7 @@ func (b CprjBuilder) Build() error {
 
 	operation := "build"
 	if b.Setup {
-		operation = "set up"
+		operation = "setup"
 	}
 	log.Info(operation + " finished successfully!")
 	return nil

--- a/pkg/builder/csolution/builder_test.go
+++ b/pkg/builder/csolution/builder_test.go
@@ -305,6 +305,9 @@ func TestInstallMissingPacks(t *testing.T) {
 				BinExtn: configs.BinExtn,
 				EtcPath: configs.EtcPath,
 			},
+			Options: builder.Options{
+				Packs: true,
+			},
 		},
 	}
 
@@ -319,6 +322,12 @@ func TestInstallMissingPacks(t *testing.T) {
 		err := b.installMissingPacks()
 		b.InstallConfigs.BinExtn = binExtn
 		assert.Error(err)
+	})
+
+	t.Run("test install missing packs with no --pack arg", func(t *testing.T) {
+		b.Options.Packs = false
+		err := b.installMissingPacks()
+		assert.Nil(err)
 	})
 }
 
@@ -443,9 +452,8 @@ func TestFormulateArg(t *testing.T) {
 	}
 
 	t.Run("test default arg", func(t *testing.T) {
-		args, err := b.formulateArgs([]string{"convert"})
+		args := b.formulateArgs([]string{"convert"})
 		strArg := utils.NormalizePath(strings.Join(args, " "))
-		assert.Nil(err)
 		assert.Equal("convert --solution=../../../test/"+testDir+"/Test.csolution.yml --no-check-schema --no-update-rte", strArg)
 	})
 
@@ -455,9 +463,8 @@ func TestFormulateArg(t *testing.T) {
 			Contexts:      []string{"test.Debug+Target", "test.Release+Target"},
 			UseContextSet: true,
 		}
-		args, err := b.formulateArgs([]string{"convert"})
+		args := b.formulateArgs([]string{"convert"})
 		strArg := utils.NormalizePath(strings.Join(args, " "))
-		assert.Nil(err)
 		assert.Equal("convert --solution=../../../test/"+testDir+"/Test.csolution.yml --no-check-schema --no-update-rte --context=test.Debug+Target --context=test.Release+Target --context-set", strArg)
 	})
 }
@@ -474,7 +481,7 @@ func TestGetCbuildSetFilePath(t *testing.T) {
 	t.Run("test invalid input file", func(t *testing.T) {
 		b.InputFile = filepath.Join(testRoot, testDir, "TestSolution/invalid_file.yml")
 
-		path, err := b.getSetFilePath()
+		path, err := b.getCbuildSetFilePath()
 		assert.Error(err)
 		assert.Equal(path, "")
 	})
@@ -482,7 +489,7 @@ func TestGetCbuildSetFilePath(t *testing.T) {
 	t.Run("test get cbuild-set file path", func(t *testing.T) {
 		b.InputFile = filepath.Join(testRoot, testDir, "TestSolution/test.csolution.yml")
 
-		path, err := b.getSetFilePath()
+		path, err := b.getCbuildSetFilePath()
 		assert.Nil(err)
 		assert.Equal(path, utils.NormalizePath(filepath.Join(testRoot, testDir, "TestSolution/test.cbuild-set.yml")))
 	})

--- a/pkg/builder/interface.go
+++ b/pkg/builder/interface.go
@@ -21,6 +21,7 @@ type BuilderParams struct {
 	Options        Options
 	InputFile      string
 	InstallConfigs utils.Configurations
+	Setup          bool
 }
 
 type Options struct {


### PR DESCRIPTION
Addressing partially https://github.com/Open-CMSIS-Pack/devtools/issues/1322

```
cbuild: Build Invocation test (C) 2024 Arm Ltd. and Contributors

Usage:
  cbuild [command] <name>.csolution.yml [options]

Commands:
  buildcprj   Use a *.CPRJ file as build input
  help        Help about any command
  list        List information about environment, toolchains, and contexts
  setup       Initialize project
```

```
$ cbuild setup -h
Initialize project

Usage:
  cbuild setup <name>.csolution.yml [options]

Options:
      --cbuild2cmake       Use cbuild2cmake
  -C, --clean              Remove intermediate and output directories
  -c, --context arg [...]  Input context names [<project-name>][.<build-type>][+<target-type>]
  -S, --context-set        Use context set
  -d, --debug              Enable debug messages
      --frozen-packs       The list of packs from cbuild-pack.yml is frozen and raises error if not up-to-date
  -g, --generator arg      Select build system generator (default "Ninja")
  -h, --help               Print usage
  -j, --jobs int           Number of job slots for parallel execution
  -l, --load arg           Set policy for packs loading [latest | all | required]
      --log arg            Save output messages in a log file
  -O, --output arg         Set directory for all output files
  -p, --packs              Download missing software packs with cpackget
  -q, --quiet              Suppress output messages except build invocations
  -r, --rebuild            Remove intermediate and output directories and rebuild
  -s, --schema             Validate project input file(s) against schema (default true)
  -t, --target arg         Optional CMake target name
      --toolchain arg      Input toolchain to be used
      --update-rte         Update the RTE directory and files
  -v, --verbose            Enable verbose messages from toolchain builds

```