### PR TITLE
Improve cmake `--target` option handling for `cbuild2cmake`

### DIFF
--- a/pkg/builder/cbuildidx/builder_test.go
+++ b/pkg/builder/cbuildidx/builder_test.go
@@ -221,3 +221,42 @@ func TestBuild(t *testing.T) {
 		assert.Nil(err)
 	})
 }
+
+func TestBuildAllContexts(t *testing.T) {
+	assert := assert.New(t)
+	configs := inittest.GetTestConfigs(testRoot, testDir)
+
+	b := CbuildIdxBuilder{
+		builder.BuilderParams{
+			Runner:    RunnerMock{},
+			InputFile: filepath.Join(testRoot, testDir, "Hello.cbuild-idx.yml"),
+			Options: builder.Options{
+				Contexts: []string{}, // = build all contexts
+				OutDir:   filepath.Join(testRoot, testDir, "OutDir"),
+				Packs:    true,
+			},
+			InstallConfigs: utils.Configurations{
+				BinPath: configs.BinPath,
+				BinExtn: configs.BinExtn,
+				EtcPath: configs.EtcPath,
+			},
+			BuildContexts: []string{"Hello.Debug+AVH"},
+		},
+	}
+	t.Run("test build cbuild-idx", func(t *testing.T) {
+		err := b.Build()
+		assert.Nil(err)
+	})
+
+	t.Run("test build target option", func(t *testing.T) {
+		b.Options.Target = "Hello.Debug+AVH"
+		err := b.Build()
+		assert.Nil(err)
+	})
+
+	t.Run("test setup", func(t *testing.T) {
+		b.Setup = true
+		err := b.Build()
+		assert.Nil(err)
+	})
+}

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -305,7 +305,6 @@ func (b CSolutionBuilder) getProjsBuilders(selectedContexts []string) (projBuild
 
 	var projBuilder builder.IBuilderInterface
 	if b.Options.UseCbuild2CMake {
-		buildOptions.Contexts = selectedContexts
 		// get idx builder
 		projBuilder = cbuildidx.CbuildIdxBuilder{
 			BuilderParams: builder.BuilderParams{
@@ -314,6 +313,7 @@ func (b CSolutionBuilder) getProjsBuilders(selectedContexts []string) (projBuild
 				InputFile:      idxFile,
 				InstallConfigs: b.InstallConfigs,
 				Setup:          b.Setup,
+				BuildContexts:  selectedContexts,
 			},
 		}
 		projBuilders = append(projBuilders, projBuilder)

--- a/pkg/builder/interface.go
+++ b/pkg/builder/interface.go
@@ -22,6 +22,7 @@ type BuilderParams struct {
 	InputFile      string
 	InstallConfigs utils.Configurations
 	Setup          bool
+	BuildContexts  []string
 }
 
 type Options struct {


### PR DESCRIPTION
Avoid replacing command line options `b.Options.Contexts`
Improve `--target` option handling, enabling additional cmake targets - related to https://github.com/Open-CMSIS-Pack/cbuild2cmake/issues/87