### PR TITLE
Added build summary message

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -8,12 +8,14 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -340,5 +342,12 @@ func RemoveVersionRange(str string) string {
 }
 
 func LogStdMsg(msg string) {
-	_, _ = log.StandardLogger().Out.Write([]byte(msg + "\n"))
+	if msg != "" {
+		_, _ = log.StandardLogger().Out.Write([]byte(msg + "\n"))
+	}
+}
+
+func FormatTime(time time.Duration) string {
+	// Format time in "hh:mm:ss"
+	return fmt.Sprintf("%02d:%02d:%02d", int(time.Hours()), int(time.Minutes())%60, int(time.Seconds())%60)
 }


### PR DESCRIPTION
Addressing: https://github.com/Open-CMSIS-Pack/devtools/issues/1293

At the moment, it's not feasible to separate build logs for different projects in cbuild2cmake. Therefore, the change addresses only the overarching build summary message, indicating: 
- `Build summary: Build completed successfully - Time Elapsed: 00:00:16`
- `Build summary: Build failed - Time Elapsed: 00:00:11`