### PR TITLE
Removed Inactivated linters from lint jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,11 +30,19 @@ jobs:
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
-      - uses: golangci/golangci-lint-action@38e1018663fa5173f3968ea0777460d3de38f256 # v5.3.0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: |
+            **/go.mod
+            **/go.sum
+
+      - uses: golangci/golangci-lint-action@v6.0.1
         with:
           version: latest
           skip-cache: true
-          args: "--verbose --print-issued-lines --print-linter-name --out-${NO_FUTURE}format colored-line-number --timeout 300s --max-issues-per-linter 0 --max-same-issues 0
+          args: "--verbose --print-issued-lines --print-linter-name --out-${NO_FUTURE}format colored-line-number --timeout 300s --max-issues-per-linter 0 --max-same-issues 0"
 
   format:
     name: Format

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,17 +8,15 @@ run:
 linters:
   disable-all: true # Disable defaults, then enable the ones we want
   enable:
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
     - bodyclose
     - stylecheck
     - gosec
     - goimports
+    - gofmt


### PR DESCRIPTION
  level=error msg="[linters_context] `structcheck`: This linter is fully inactivated: it will not produce any reports."
  level=error msg="[linters_context] `varcheck`: This linter is fully inactivated: it will not produce any reports."
  level=error msg="[linters_context] `deadcode`: This linter is fully inactivated: it will not produce any reports."