### PR TITLE
[cbuild] Fix `setup` command in `cbuild2cmake` mode to use only `<context>-database` targets

### DIFF
--- a/pkg/builder/cbuildidx/builder.go
+++ b/pkg/builder/cbuildidx/builder.go
@@ -204,12 +204,10 @@ func (b CbuildIdxBuilder) Build() error {
 
 	if b.Options.Target != "" {
 		args = append(args, "--target", b.Options.Target)
+	} else if b.Setup {
+		args = append(args, "--target", b.BuildContext+"-database")
 	} else if b.BuildContext != "" {
 		args = append(args, "--target", b.BuildContext)
-	}
-
-	if b.Setup {
-		args = append(args, "--target", b.BuildContext+"-database")
 	}
 
 	if b.Options.Generator == "Ninja" && !(b.Options.Debug || b.Options.Verbose) {


### PR DESCRIPTION
Address https://github.com/Open-CMSIS-Pack/devtools/issues/1563