### PR TITLE
Set default log mode to Warn+ and streamline error handling and cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,6 +183,12 @@ jobs:
     name: 'Coverage check'
     runs-on: ubuntu-latest
     steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install \
+            ninja-build
+
       - name: Check out repository code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,6 +89,23 @@ jobs:
     name: 'Test (${{ matrix.target }})'
     runs-on: ${{ matrix.platform }}
     steps:
+      - name: Install macos deps
+        if: ${{ startsWith(matrix.platform, 'macos') }}
+        run: |
+          brew install \
+            ninja
+
+      - name: Install linux deps
+        if: ${{ startsWith(matrix.platform, 'ubuntu') }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install \
+            ninja-build
+
+      - name: Install windows deps
+        if: ${{ startsWith(matrix.platform, 'windows') }}
+        run: choco install -y ninja
+
       - name: Check out repository code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 

--- a/cmd/cbuild/commands/build/buildcprj.go
+++ b/cmd/cbuild/commands/build/buildcprj.go
@@ -6,11 +6,11 @@
 package build
 
 import (
-	"errors"
 	"path/filepath"
 
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder/cproject"
+	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/errutils"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/utils"
 	"github.com/spf13/cobra"
 )
@@ -21,7 +21,7 @@ func BuildCPRJ(cmd *cobra.Command, args []string) error {
 		inputFile = args[0]
 	} else {
 		_ = cmd.Help()
-		return errors.New("invalid arguments")
+		return errutils.New(errutils.ErrInvalidCmdLineArg)
 	}
 
 	intDir, _ := cmd.Flags().GetString("intdir")
@@ -73,11 +73,12 @@ func BuildCPRJ(cmd *cobra.Command, args []string) error {
 	}
 
 	fileExtension := filepath.Ext(inputFile)
+	expectedExtension := ".cprj"
 	var b builder.IBuilderInterface
-	if fileExtension == ".cprj" {
+	if fileExtension == expectedExtension {
 		b = cproject.CprjBuilder{BuilderParams: params}
 	} else {
-		return errors.New("invalid file argument")
+		return errutils.New(errutils.ErrInvalidFileExtension, fileExtension, expectedExtension)
 	}
 
 	return b.Build()

--- a/cmd/cbuild/commands/build/buildcprj_test.go
+++ b/cmd/cbuild/commands/build/buildcprj_test.go
@@ -49,7 +49,7 @@ func TestPreLogConfiguration(t *testing.T) {
 		cmd := commands.NewRootCmd()
 		cmd.SetArgs([]string{"buildcprj", cprjFile, "-C"})
 		_ = cmd.Execute()
-		assert.Equal(log.InfoLevel, log.GetLevel())
+		assert.Equal(log.WarnLevel, log.GetLevel())
 	})
 
 	t.Run("test quiet verbosity level", func(t *testing.T) {

--- a/cmd/cbuild/commands/root.go
+++ b/cmd/cbuild/commands/root.go
@@ -239,17 +239,14 @@ func FlagErrorFunc(cmd *cobra.Command, err error) error {
 }
 
 func getBuilder(inputFile string, params builder.BuilderParams) (builder.IBuilderInterface, error) {
-	fileExtension := filepath.Ext(inputFile)
-	var b builder.IBuilderInterface
+	fileName := filepath.Base(inputFile)
 
-	switch fileExtension {
-	case ".cprj":
-		b = cproject.CprjBuilder{BuilderParams: params}
-	case ".yml":
-		b = csolution.CSolutionBuilder{BuilderParams: params}
+	switch {
+	case strings.HasSuffix(fileName, ".csolution.yml"):
+		return csolution.CSolutionBuilder{BuilderParams: params}, nil
+	case strings.HasSuffix(fileName, ".cprj"):
+		return cproject.CprjBuilder{BuilderParams: params}, nil
 	default:
-		return nil, errutils.New(errutils.ErrInvalidFileExtension, fileExtension, ".cprj & .yml")
+		return nil, errutils.New(errutils.ErrInvalidFileExtension, fileName, ".csolution.yml & .cprj")
 	}
-
-	return b, nil
 }

--- a/cmd/cbuild/commands/root.go
+++ b/cmd/cbuild/commands/root.go
@@ -66,12 +66,10 @@ func preConfiguration(cmd *cobra.Command, args []string) error {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	logFile, _ := cmd.Flags().GetString("log")
 
-	if debug {
+	if debug || verbose {
 		log.SetLevel(log.DebugLevel)
 	} else if quiet {
 		log.SetLevel(log.ErrorLevel)
-	} else if verbose {
-		log.SetLevel(log.TraceLevel)
 	}
 
 	if logFile != "" {

--- a/cmd/cbuild/commands/root_test.go
+++ b/cmd/cbuild/commands/root_test.go
@@ -83,7 +83,7 @@ func TestPreLogConfiguration(t *testing.T) {
 		cmd.SetArgs([]string{"--version"})
 		err := cmd.Execute()
 		assert.Nil(err)
-		assert.Equal(log.InfoLevel, log.GetLevel())
+		assert.Equal(log.WarnLevel, log.GetLevel())
 	})
 
 	t.Run("test quiet verbosity level", func(t *testing.T) {

--- a/cmd/cbuild/commands/setup/setup.go
+++ b/cmd/cbuild/commands/setup/setup.go
@@ -6,12 +6,12 @@
 package setup
 
 import (
-	"errors"
 	"path/filepath"
 	"strings"
 
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder/csolution"
+	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/errutils"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/utils"
 	"github.com/spf13/cobra"
 )
@@ -22,12 +22,14 @@ func SetUpProject(cmd *cobra.Command, args []string) error {
 		inputFile = args[0]
 	} else {
 		_ = cmd.Help()
-		return errors.New("invalid arguments")
+		return errutils.New(errutils.ErrInvalidCmdLineArg)
 	}
 
 	fileName := filepath.Base(inputFile)
-	if !strings.HasSuffix(fileName, ".csolution.yml") {
-		return errors.New("invalid file argument")
+	expectedExtension := ".csolution.yml"
+
+	if !strings.HasSuffix(fileName, expectedExtension) {
+		return errutils.New(errutils.ErrInvalidFile, fileName, "<project.>"+expectedExtension)
 	}
 
 	logFile, _ := cmd.Flags().GetString("log")

--- a/cmd/cbuild/commands/setup/setup.go
+++ b/cmd/cbuild/commands/setup/setup.go
@@ -29,7 +29,7 @@ func SetUpProject(cmd *cobra.Command, args []string) error {
 	expectedExtension := ".csolution.yml"
 
 	if !strings.HasSuffix(fileName, expectedExtension) {
-		return errutils.New(errutils.ErrInvalidFile, fileName, "<project.>"+expectedExtension)
+		return errutils.New(errutils.ErrInvalidFileExtension, fileName, ".csolution.yml")
 	}
 
 	logFile, _ := cmd.Flags().GetString("log")

--- a/cmd/cbuild/main.go
+++ b/cmd/cbuild/main.go
@@ -25,7 +25,6 @@ func main() {
 	cmd := commands.NewRootCmd()
 	err := cmd.Execute()
 	if err != nil {
-		log.Error(err)
 		if exitError, ok := err.(*exec.ExitError); ok {
 			os.Exit(exitError.ExitCode())
 		} else {

--- a/pkg/builder/cbuildidx/builder.go
+++ b/pkg/builder/cbuildidx/builder.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	builder "github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder"
+	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/errutils"
 	utils "github.com/Open-CMSIS-Pack/cbuild/v2/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
@@ -24,8 +25,9 @@ type CbuildIdxBuilder struct {
 
 func (b CbuildIdxBuilder) checkCbuildIdx() error {
 	fileName := filepath.Base(b.InputFile)
-	if !strings.HasSuffix(fileName, ".cbuild-idx.yml") {
-		err := errors.New(".cbuild-idx.yml file not found")
+	expectedExtension := ".cbuild-idx.yml"
+	if !strings.HasSuffix(fileName, expectedExtension) {
+		err := errutils.New(errutils.ErrInvalidFile, fileName, "<project>."+expectedExtension)
 		return err
 	} else {
 		if _, err := os.Stat(b.InputFile); os.IsNotExist(err) {
@@ -132,8 +134,7 @@ func (b CbuildIdxBuilder) Build() error {
 	_ = utils.UpdateEnvVars(vars.BinPath, vars.EtcPath)
 
 	if len(b.Options.Contexts) == 0 && b.BuildContext == "" {
-		err = errors.New("error no context(s) to process")
-		return err
+		return errutils.New(errutils.ErrNoContextFound)
 	}
 
 	dirs := builder.BuildDirs{

--- a/pkg/builder/cbuildidx/builder_test.go
+++ b/pkg/builder/cbuildidx/builder_test.go
@@ -7,13 +7,13 @@
 package cbuildidx
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	builder "github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder"
+	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/errutils"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/inittest"
 	utils "github.com/Open-CMSIS-Pack/cbuild/v2/pkg/utils"
 	"github.com/stretchr/testify/assert"
@@ -39,7 +39,7 @@ func (r RunnerMock) ExecuteCommand(program string, quiet bool, args ...string) (
 	} else if strings.Contains(program, "ninja") {
 	} else if strings.Contains(program, "xmllint") {
 	} else {
-		return "", errors.New("invalid command")
+		return "", errutils.New(errutils.ErrInvalidCommand)
 	}
 	return "", nil
 }

--- a/pkg/builder/cbuildidx/builder_test.go
+++ b/pkg/builder/cbuildidx/builder_test.go
@@ -39,37 +39,9 @@ func (r RunnerMock) ExecuteCommand(program string, quiet bool, args ...string) (
 	} else if strings.Contains(program, "ninja") {
 	} else if strings.Contains(program, "xmllint") {
 	} else {
-		return "", errutils.New(errutils.ErrInvalidCommand)
+		return "", errutils.New(errutils.ErrInvalidCommand, program)
 	}
 	return "", nil
-}
-
-func TestCheckCbuildIdx(t *testing.T) {
-	assert := assert.New(t)
-
-	b := CbuildIdxBuilder{
-		builder.BuilderParams{
-			Runner: RunnerMock{},
-		},
-	}
-
-	t.Run("test valid cbuild-idx", func(t *testing.T) {
-		b.InputFile = filepath.Join(testRoot, testDir, "Hello.cbuild-idx.yml")
-		err := b.checkCbuildIdx()
-		assert.Nil(err)
-	})
-
-	t.Run("test existent file, invalid extension", func(t *testing.T) {
-		b.InputFile = filepath.Join(testRoot, testDir, "main.c")
-		err := b.checkCbuildIdx()
-		assert.Error(err)
-	})
-
-	t.Run("test invalid file", func(t *testing.T) {
-		b.InputFile = filepath.Join(testRoot, testDir, "invalid-file.cbuild-idx.yml")
-		err := b.checkCbuildIdx()
-		assert.Error(err)
-	})
 }
 
 func TestGetDirs(t *testing.T) {

--- a/pkg/builder/cproject/builder.go
+++ b/pkg/builder/cproject/builder.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	builder "github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder"
+	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/errutils"
 	utils "github.com/Open-CMSIS-Pack/cbuild/v2/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
@@ -23,9 +24,10 @@ type CprjBuilder struct {
 }
 
 func (b CprjBuilder) checkCprj() error {
-	if filepath.Ext(b.InputFile) != ".cprj" {
-		err := errors.New("missing required argument <project>.cprj")
-		return err
+	fileExtension := filepath.Ext(b.InputFile)
+	expectedExtension := ".cprj"
+	if fileExtension != expectedExtension {
+		return errutils.New(errutils.ErrInvalidFileExtension, fileExtension, expectedExtension)
 	} else {
 		if _, err := os.Stat(b.InputFile); os.IsNotExist(err) {
 			log.Error("project file " + b.InputFile + " does not exist")
@@ -166,8 +168,7 @@ func (b CprjBuilder) Build() error {
 	if _, err := os.Stat(packlistFile); !os.IsNotExist(err) {
 		if b.Options.Packs {
 			if vars.CpackgetBin == "" {
-				err := errors.New("cpackget was not found, missing packs cannot be downloaded")
-				return err
+				return errutils.New(errutils.ErrBinaryNotFound, "cpackget", "missing packs cannot be downloaded")
 			}
 			args = []string{"add", "--agree-embedded-license", "--no-dependencies", "--packs-list-filename", packlistFile}
 			if b.Options.Debug {
@@ -180,7 +181,7 @@ func (b CprjBuilder) Build() error {
 				return err
 			}
 		} else {
-			err := errors.New("missing packs must be installed, rerun cbuild with the --packs option")
+			err := errutils.New(errutils.ErrMissingPacks)
 			log.Error(err)
 			return err
 		}

--- a/pkg/builder/cproject/builder.go
+++ b/pkg/builder/cproject/builder.go
@@ -167,7 +167,8 @@ func (b CprjBuilder) build() error {
 	if _, err := os.Stat(packlistFile); !os.IsNotExist(err) {
 		if b.Options.Packs {
 			if vars.CpackgetBin == "" {
-				err = errutils.New(errutils.ErrBinaryNotFound, "cpackget", "missing packs cannot be downloaded")
+				err = errutils.New(errutils.ErrBinaryNotFound,
+					"cpackget", "in "+vars.BinPath+". Missing packs cannot be installed")
 				return err
 			}
 			args = []string{"add", "--agree-embedded-license", "--no-dependencies", "--packs-list-filename", packlistFile}

--- a/pkg/builder/cproject/builder_test.go
+++ b/pkg/builder/cproject/builder_test.go
@@ -45,7 +45,7 @@ func (r RunnerMock) ExecuteCommand(program string, quiet bool, args ...string) (
 	} else if strings.Contains(program, "ninja") {
 	} else if strings.Contains(program, "xmllint") {
 	} else {
-		return "", errutils.New(errutils.ErrInvalidCommand)
+		return "", errutils.New(errutils.ErrInvalidCommand, program)
 	}
 	return "", nil
 }

--- a/pkg/builder/cproject/builder_test.go
+++ b/pkg/builder/cproject/builder_test.go
@@ -7,7 +7,6 @@
 package cproject
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -15,6 +14,7 @@ import (
 	"testing"
 
 	builder "github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder"
+	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/errutils"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/inittest"
 	utils "github.com/Open-CMSIS-Pack/cbuild/v2/pkg/utils"
 	"github.com/stretchr/testify/assert"
@@ -45,7 +45,7 @@ func (r RunnerMock) ExecuteCommand(program string, quiet bool, args ...string) (
 	} else if strings.Contains(program, "ninja") {
 	} else if strings.Contains(program, "xmllint") {
 	} else {
-		return "", errors.New("invalid command")
+		return "", errutils.New(errutils.ErrInvalidCommand)
 	}
 	return "", nil
 }

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -20,6 +20,7 @@ import (
 	builder "github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder/cbuildidx"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder/cproject"
+	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/errutils"
 	utils "github.com/Open-CMSIS-Pack/cbuild/v2/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
@@ -178,7 +179,7 @@ func (b CSolutionBuilder) generateBuildFiles() (err error) {
 
 		// Ensure at least one context exists
 		if len(allContexts) == 0 {
-			return errors.New("error no context(s) found")
+			return errutils.New(errutils.ErrNoContextFound)
 		}
 
 		// Resolve the selected contexts including the default one
@@ -234,7 +235,7 @@ func (b CSolutionBuilder) getCprjFilePath(idxFile string, context string) (strin
 			}
 		}
 		if path == "" {
-			err = errors.New("cprj file path not found")
+			err = errutils.New(errutils.ErrNoRefToCPRJFile, context+".cprj", idxFile)
 		} else {
 			cprjPath = filepath.Join(filepath.Dir(idxFile), filepath.Dir(path), context+".cprj")
 		}

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -234,7 +234,7 @@ func (b CSolutionBuilder) getCprjFilePath(idxFile string, context string) (strin
 			}
 		}
 		if path == "" {
-			err = errutils.New(errutils.ErrNoRefToCPRJFile, context+".cprj", idxFile)
+			err = errutils.New(errutils.ErrCPRJNotFound, context+".cprj")
 		} else {
 			cprjPath = filepath.Join(filepath.Dir(idxFile), filepath.Dir(path), context+".cprj")
 		}
@@ -273,26 +273,33 @@ func (b CSolutionBuilder) getCSolutionPath() (path string, err error) {
 }
 
 func (b CSolutionBuilder) getIdxFilePath() (string, error) {
-	projName, err := utils.GetProjectName(b.InputFile)
-	if err != nil {
-		return "", err
-	}
-
+	projName := b.getProjectName(b.InputFile)
 	outputDir := b.Options.Output
 	if outputDir == "" {
 		outputDir = filepath.Dir(b.InputFile)
 	}
 	idxFilePath := utils.NormalizePath(filepath.Join(outputDir, projName+".cbuild-idx.yml"))
-	return idxFilePath, nil
-}
-
-func (b CSolutionBuilder) getCbuildSetFilePath() (string, error) {
-	projName, err := utils.GetProjectName(b.InputFile)
+	_, err := utils.FileExists(idxFilePath)
 	if err != nil {
 		return "", err
 	}
+	return idxFilePath, nil
+}
+
+func (b CSolutionBuilder) getProjectName(csolutionFile string) (projectName string) {
+	csolutionFile = utils.NormalizePath(csolutionFile)
+	nameTokens := strings.Split(filepath.Base(csolutionFile), ".")
+	return nameTokens[0]
+}
+
+func (b CSolutionBuilder) getCbuildSetFilePath() (string, error) {
+	projName := b.getProjectName(b.InputFile)
 	setFilePath := utils.NormalizePath(filepath.Join(filepath.Dir(b.InputFile), projName+".cbuild-set.yml"))
 
+	_, err := utils.FileExists(setFilePath)
+	if err != nil {
+		return "", err
+	}
 	return setFilePath, nil
 }
 

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -114,7 +114,6 @@ func (b CSolutionBuilder) installMissingPacks() (err error) {
 		args = []string{"add", pack, "--force-reinstall", "--agree-embedded-license", "--no-dependencies"}
 		cpackgetBin := filepath.Join(b.InstallConfigs.BinPath, "cpackget"+b.InstallConfigs.BinExtn)
 		if _, err := os.Stat(cpackgetBin); os.IsNotExist(err) {
-			log.Error("error cpackget not found")
 			return err
 		}
 
@@ -269,9 +268,7 @@ func (b CSolutionBuilder) getSelectedContexts(filePath string) ([]string, error)
 
 func (b CSolutionBuilder) getCSolutionPath() (path string, err error) {
 	path = filepath.Join(b.InstallConfigs.BinPath, "csolution"+b.InstallConfigs.BinExtn)
-	if _, err = os.Stat(path); os.IsNotExist(err) {
-		log.Error("error csolution was not found: \"" + err.Error() + "\"")
-	}
+	_, err = os.Stat(path)
 	return
 }
 
@@ -339,7 +336,6 @@ func (b CSolutionBuilder) getProjsBuilders(selectedContexts []string) (projBuild
 		} else {
 			cprjFile, err := b.getCprjFilePath(idxFile, context)
 			if err != nil {
-				log.Error("error getting cprj file: " + err.Error())
 				return projBuilders, err
 			}
 
@@ -388,8 +384,9 @@ func (b CSolutionBuilder) getBuilderInputFile(builder builder.IBuilderInterface)
 func (b CSolutionBuilder) cleanContexts(projBuilders []builder.IBuilderInterface) (err error) {
 	for index := range projBuilders {
 		b.setBuilderOptions(&projBuilders[index], true)
-		err = projBuilders[index].Build()
+		cleanErr := projBuilders[index].Build()
 		if err != nil {
+			err = cleanErr
 			log.Error("error cleaning '" + b.getBuilderInputFile(projBuilders[index]) + "'")
 		}
 	}
@@ -424,8 +421,9 @@ func (b CSolutionBuilder) buildContexts(selectedContexts []string, projBuilders 
 		b.setBuilderOptions(&projBuilders[index], false)
 
 		buildStartTime := time.Now()
-		err = projBuilders[index].Build()
-		if err != nil {
+		buildErr := projBuilders[index].Build()
+		if buildErr != nil {
+			err = buildErr
 			buildFailCnt += 1
 		} else {
 			buildPassCnt += 1
@@ -604,12 +602,14 @@ func (b CSolutionBuilder) Build() (err error) {
 	if err = b.installMissingPacks(); err != nil {
 		// Continue with build files generation upon setup command
 		if !b.Setup {
+			log.Error(err)
 			return err
 		}
 	}
 
 	// STEP 2: Generate build file(s)
 	if err = b.generateBuildFiles(); err != nil {
+		log.Error(err)
 		return err
 	}
 

--- a/pkg/builder/csolution/builder_test.go
+++ b/pkg/builder/csolution/builder_test.go
@@ -7,13 +7,13 @@
 package csolution
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	builder "github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder"
+	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/errutils"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/inittest"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/utils"
 	"github.com/stretchr/testify/assert"
@@ -52,7 +52,7 @@ func (r RunnerMock) ExecuteCommand(program string, quiet bool, args ...string) (
 	} else if strings.Contains(program, "ninja") {
 	} else if strings.Contains(program, "xmllint") {
 	} else {
-		return "", errors.New("invalid command")
+		return "", errutils.New(errutils.ErrInvalidCommand)
 	}
 	return "", nil
 }

--- a/pkg/builder/csolution/builder_test.go
+++ b/pkg/builder/csolution/builder_test.go
@@ -52,7 +52,7 @@ func (r RunnerMock) ExecuteCommand(program string, quiet bool, args ...string) (
 	} else if strings.Contains(program, "ninja") {
 	} else if strings.Contains(program, "xmllint") {
 	} else {
-		return "", errutils.New(errutils.ErrInvalidCommand)
+		return "", errutils.New(errutils.ErrInvalidCommand, program)
 	}
 	return "", nil
 }
@@ -430,15 +430,6 @@ func TestGetIdxFilePath(t *testing.T) {
 		path, err := b.getIdxFilePath()
 		assert.Nil(err)
 		assert.Equal(path, utils.NormalizePath(filepath.Join(testRoot, testDir, "TestSolution/test.cbuild-idx.yml")))
-	})
-
-	t.Run("test get idx file path with output path", func(t *testing.T) {
-		b.InputFile = filepath.Join(testRoot, testDir, "TestSolution/test.csolution.yml")
-		b.Options.Output = filepath.Join(testRoot, testDir, "outdir")
-
-		path, err := b.getIdxFilePath()
-		assert.Nil(err)
-		assert.Equal(path, utils.NormalizePath(b.Options.Output+"/test.cbuild-idx.yml"))
 	})
 }
 

--- a/pkg/builder/interface.go
+++ b/pkg/builder/interface.go
@@ -73,13 +73,11 @@ func (b BuilderParams) GetInternalVars() (vars InternalVars, err error) {
 
 	vars.CbuildgenBin = filepath.Join(vars.BinPath, "cbuildgen"+b.InstallConfigs.BinExtn)
 	if _, err := os.Stat(vars.CbuildgenBin); os.IsNotExist(err) {
-		log.Error("cbuildgen was not found")
 		return vars, err
 	}
 
 	vars.Cbuild2cmakeBin = filepath.Join(vars.BinPath, "cbuild2cmake"+b.InstallConfigs.BinExtn)
 	if _, err := os.Stat(vars.Cbuild2cmakeBin); os.IsNotExist(err) {
-		log.Error("cbuild2cmake was not found")
 		return vars, err
 	}
 

--- a/pkg/errutils/errutils.go
+++ b/pkg/errutils/errutils.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package errutils
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	ErrInvalidFileExtension     = "unsupported file extension: %s. Supported extension(s): %s"
+	ErrInvalidCmdLineArg        = "expected only one argument specifying the input file"
+	ErrFileNotExist             = "file %s does not exist"
+	ErrNoContextFound           = "no context(s) found to process"
+	ErrBinaryNotFound           = "%s binary not found %s"
+	ErrMissingPacks             = "missing packs must be installed, rerun cbuild with the --packs option"
+	ErrPathNotFound             = "path %s not found"
+	ErrInvalidContextFormat     = "invalid context format. Expected [project][.buildType][+targetType]"
+	ErrInvalidCSolutionFileName = "invalid csolution file name format. Expected '<projectname>.csolution.yml'"
+	ErrNoFilteredContextFound   = "no suitable context matched for filter '%s'"
+	ErrNoRefToCPRJFile          = "reference to '%s' not found in '%s' file"
+	ErrInvalidCommand           = "invalid command entered. Please check your input and try again"
+	ErrInvalidFile              = "invalid file: %s. Expected '%s' file"
+)
+
+func New(errorFormat string, args ...any) error {
+	errMsg := fmt.Sprintf(errorFormat, args...)
+	return errors.New(errMsg)
+}

--- a/pkg/errutils/errutils.go
+++ b/pkg/errutils/errutils.go
@@ -12,19 +12,17 @@ import (
 )
 
 const (
-	ErrInvalidFileExtension     = "unsupported file extension: %s. Supported extension(s): %s"
-	ErrInvalidCmdLineArg        = "expected only one argument specifying the input file"
-	ErrFileNotExist             = "file %s does not exist"
-	ErrNoContextFound           = "no context(s) found to process"
-	ErrBinaryNotFound           = "%s binary not found %s"
-	ErrMissingPacks             = "missing packs must be installed, rerun cbuild with the --packs option"
-	ErrPathNotFound             = "path %s not found"
-	ErrInvalidContextFormat     = "invalid context format. Expected [project][.buildType][+targetType]"
-	ErrInvalidCSolutionFileName = "invalid csolution file name format. Expected '<projectname>.csolution.yml'"
-	ErrNoFilteredContextFound   = "no suitable context matched for filter '%s'"
-	ErrNoRefToCPRJFile          = "reference to '%s' not found in '%s' file"
-	ErrInvalidCommand           = "invalid command entered. Please check your input and try again"
-	ErrInvalidFile              = "invalid file: %s. Expected '%s' file"
+	ErrInvalidFileExtension   = "invalid file extension: '%s'. Expected: '%s'"
+	ErrInvalidCmdLineArg      = "multiple input files"
+	ErrFileNotExist           = "file %s does not exist"
+	ErrNoContextFound         = "no context found to process"
+	ErrBinaryNotFound         = "%s not found %s"
+	ErrMissingPacks           = "missing packs. Use --packs option with cbuild command to install them"
+	ErrETCPathNotFound        = "couldn't locate '%s' directory relative to '%s'"
+	ErrInvalidContextFormat   = "invalid context format. Expected [<project-name>][.<build-type>][+<target-type>]"
+	ErrNoFilteredContextFound = "no valid context found for '%s'"
+	ErrInvalidCommand         = "invalid command '%s'. Run 'cbuild --help' for supported commands"
+	ErrCPRJNotFound           = "couldn't locate %s file"
 )
 
 func New(errorFormat string, args ...any) error {

--- a/pkg/errutils/errutils_test.go
+++ b/pkg/errutils/errutils_test.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package errutils
+
+import (
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name        string
+		errorFormat string
+		args        []interface{}
+		expectedErr string
+	}{
+		{
+			name:        "Basic usage",
+			errorFormat: "An error occurred: %s",
+			args:        []interface{}{"error details"},
+			expectedErr: "An error occurred: error details",
+		},
+		{
+			name:        "No arguments",
+			errorFormat: "An error occurred",
+			args:        nil,
+			expectedErr: "An error occurred",
+		},
+		{
+			name:        "Multiple arguments",
+			errorFormat: "Error %s: %s",
+			args:        []interface{}{"code", "error message"},
+			expectedErr: "Error code: error message",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := New(tt.errorFormat, tt.args...)
+			if err == nil {
+				t.Errorf("Expected error, got nil")
+				return
+			}
+			actualErr := err.Error()
+			if actualErr != tt.expectedErr {
+				t.Errorf("Expected error message %q, got %q", tt.expectedErr, actualErr)
+			}
+		})
+	}
+}

--- a/pkg/utils/configs.go
+++ b/pkg/utils/configs.go
@@ -7,10 +7,11 @@
 package utils
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
+
+	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/errutils"
 )
 
 type Configurations struct {
@@ -34,7 +35,7 @@ func GetInstallConfigs() (configs Configurations, err error) {
 	configs.BinPath = binPath
 	etcPath := filepath.Clean(binPath + "/../etc")
 	if _, err = os.Stat(etcPath); os.IsNotExist(err) {
-		err = errors.New(etcPath + " path was not found")
+		err = errutils.New(errutils.ErrPathNotFound, etcPath)
 		return Configurations{}, err
 	}
 	if etcPath != "" {

--- a/pkg/utils/configs.go
+++ b/pkg/utils/configs.go
@@ -35,7 +35,7 @@ func GetInstallConfigs() (configs Configurations, err error) {
 	configs.BinPath = binPath
 	etcPath := filepath.Clean(binPath + "/../etc")
 	if _, err = os.Stat(etcPath); os.IsNotExist(err) {
-		err = errutils.New(errutils.ErrPathNotFound, etcPath)
+		err = errutils.New(errutils.ErrETCPathNotFound, "../etc", configs.BinPath)
 		return Configurations{}, err
 	}
 	if etcPath != "" {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -266,15 +266,6 @@ func NormalizePath(path string) string {
 	return path
 }
 
-func GetProjectName(csolutionFile string) (projectName string, err error) {
-	csolutionFile = NormalizePath(csolutionFile)
-	nameTokens := strings.Split(filepath.Base(csolutionFile), ".")
-	if len(nameTokens) != 3 || nameTokens[1] != "csolution" || nameTokens[2] != "yml" {
-		return "", errutils.New(errutils.ErrInvalidCSolutionFileName)
-	}
-	return nameTokens[0], nil
-}
-
 func ResolveContexts(allContext []string, contextFilters []string) ([]string, error) {
 	var selectedContexts []string
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -246,27 +246,6 @@ func TestNormalizePath(t *testing.T) {
 	})
 }
 
-func TestGetProjectName(t *testing.T) {
-	assert := assert.New(t)
-	t.Run("test get project name from backslash path", func(t *testing.T) {
-		projName, err := GetProjectName("test\\input\\test.csolution.yml")
-		assert.Nil(err)
-		assert.Equal(projName, "test")
-	})
-
-	t.Run("test get project name from path", func(t *testing.T) {
-		projName, err := GetProjectName("test/input/test.csolution.yml")
-		assert.Nil(err)
-		assert.Equal(projName, "test")
-	})
-
-	t.Run("test get project name with invalid file name", func(t *testing.T) {
-		projName, err := GetProjectName("test/input/csolution.yml")
-		assert.Error(err)
-		assert.Equal(projName, "")
-	})
-}
-
 func TestResolveContexts(t *testing.T) {
 	assert := assert.New(t)
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/errutils"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/inittest"
 	"github.com/stretchr/testify/assert"
 )
@@ -384,4 +385,63 @@ func TestRemoveDuplicates(t *testing.T) {
 
 	outUniqueList = RemoveDuplicates(UniqueList)
 	assert.Equal(UniqueList, outUniqueList)
+}
+
+func TestFileExists(t *testing.T) {
+	testFile := testRoot + "/" + testDir + "/testfile.txt"
+
+	tests := []struct {
+		name         string
+		filePath     string
+		expectedBool bool
+		expectedErr  error
+	}{
+		{
+			name:         "Existing File",
+			filePath:     testFile,
+			expectedBool: true,
+			expectedErr:  nil,
+		},
+		{
+			name:         "Non-Existing File",
+			filePath:     "testdata/nonexistent.txt",
+			expectedBool: false,
+			expectedErr:  errutils.New(errutils.ErrFileNotExist, "testdata/nonexistent.txt"),
+		},
+		{
+			name:         "Invalid Path",
+			filePath:     "/invalid/path/here",
+			expectedBool: false,
+			expectedErr:  errutils.New(errutils.ErrFileNotExist, "/invalid/path/here"),
+		},
+	}
+
+	// Create test files
+	createTestFiles := func(testFile string) {
+		// Create a dummy test file
+		file, _ := os.Create(testFile)
+		file.Close()
+	}
+
+	removeTestFiles := func(testFile string) {
+		// Remove dummy test file
+		os.Remove(testFile)
+	}
+
+	createTestFiles(testFile)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exists, err := FileExists(tt.filePath)
+			if exists != tt.expectedBool {
+				t.Errorf("Expected file existence %v, got %v", tt.expectedBool, exists)
+			}
+			if (err == nil && tt.expectedErr != nil) || (err != nil && err.Error() != tt.expectedErr.Error()) {
+				t.Errorf("Expected error %v, got %v", tt.expectedErr, err)
+			}
+		})
+	}
+
+	// Clean up test files
+	removeTestFiles(testFile)
 }

--- a/test/data/TestSolution/test.cbuild-idx.yml
+++ b/test/data/TestSolution/test.cbuild-idx.yml
@@ -1,0 +1,20 @@
+build-idx:
+  generated-by: csolution version 1.1.1
+  description: test description string
+  csolution: ../data/TestSolution/test.csolution.yml
+  cprojects:
+    - cproject: ../data/TestSolution/TestProject2/test2.cproject.yml
+    - cproject: ../data/TestSolution/TestProject1/test1.cproject.yml
+  cbuilds:
+    - cbuild: test2.Debug+CM0.cbuild.yml
+      project: test2
+      configuration: .Debug+CM0
+    - cbuild: test2.Debug+CM3.cbuild.yml
+      project: test2
+      configuration: .Debug+CM3
+    - cbuild: test1.Debug+CM0.cbuild.yml
+      project: test1
+      configuration: .Debug+CM0
+    - cbuild: test1.Release+CM0.cbuild.yml
+      project: test1
+      configuration: .Release+CM0

--- a/test/data/TestSolution/test.cbuild-set.yml
+++ b/test/data/TestSolution/test.cbuild-set.yml
@@ -1,0 +1,7 @@
+cbuild-set:
+  generated-by: csolution version 2.1.0
+  contexts:
+    - context: test2.Debug+CM0
+    - context: test2.Debug+CM3
+    - context: test1.Debug+CM0
+    - context: test1.Release+CM0


### PR DESCRIPTION
This update includes the following changes:

1. To reduce log noise, the default log mode is set to Warn+, which means only warning and error messages will be logged by default.
2. Error messages have been revised to be more intuitive for users.
3. Redundant error messages have been removed.
4. Removed `error cbuild: exit status 1`
5. `.csolution.yml` is now the expected extension and `.csolution.yaml` is no longer accepted

Note: Please be informed that to get the detailed logs use `--verbose` option