### PR TITLE
[cbuild] Improve CMake `--target` handling in `cbuild2cmake` mode

### DIFF
--- a/pkg/builder/cbuildidx/builder.go
+++ b/pkg/builder/cbuildidx/builder.go
@@ -49,6 +49,11 @@ func (b CbuildIdxBuilder) clean(dirs builder.BuildDirs, vars builder.InternalVar
 	return nil
 }
 
+func (b CbuildIdxBuilder) HasExecutes() bool {
+	data, _ := utils.ParseCbuildIndexFile(b.InputFile)
+	return len(data.BuildIdx.Executes) > 0
+}
+
 func (b CbuildIdxBuilder) getDirs(context string) (dirs builder.BuildDirs, err error) {
 	if _, err := os.Stat(b.InputFile); os.IsNotExist(err) {
 		return dirs, err

--- a/pkg/builder/cbuildidx/builder_test.go
+++ b/pkg/builder/cbuildidx/builder_test.go
@@ -342,3 +342,18 @@ func TestValidateNinjaVersion(t *testing.T) {
 		assert.False(output)
 	})
 }
+
+func TestHasExecutes(t *testing.T) {
+	assert := assert.New(t)
+
+	b := CbuildIdxBuilder{
+		builder.BuilderParams{
+			Runner:    RunnerMock{},
+			InputFile: filepath.Join(testRoot, testDir, "Test.cbuild-idx.yml"),
+		},
+	}
+
+	t.Run("validate solution has executes nodes", func(t *testing.T) {
+		assert.True(b.HasExecutes())
+	})
+}

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -436,6 +436,18 @@ func (b CSolutionBuilder) buildContexts(selectedContexts []string, projBuilders 
 	if !b.Setup {
 		buildSummary := fmt.Sprintf("Build summary: %d succeeded, %d failed - Time Elapsed: %s", buildPassCnt, buildFailCnt, utils.FormatTime(totalBuildTime))
 		sepLen := len(buildSummary)
+		// if no context is specified, run cmake build target 'all' to trigger 'executes' steps
+		if b.Options.UseCbuild2CMake && len(b.Options.Contexts) == 0 && projBuilders[0].(cbuildidx.CbuildIdxBuilder).HasExecutes() {
+			infoMsg := "Check all CMake targets"
+			sepLen := len(infoMsg)
+			utils.PrintSeparator("-", sepLen)
+			utils.LogStdMsg(infoMsg)
+			builder := projBuilders[0].(cbuildidx.CbuildIdxBuilder)
+			builder.Options.Target = "all"
+			if buildErr := builder.Build(); buildErr != nil {
+				err = buildErr
+			}
+		}
 		utils.PrintSeparator("-", sepLen)
 		utils.LogStdMsg(buildSummary)
 		utils.PrintSeparator("=", sepLen)
@@ -601,7 +613,12 @@ func (b CSolutionBuilder) build() (err error) {
 		}
 	}
 
-	err = b.buildContexts(selectedContexts, projBuilders)
+	if len(b.Options.Target) == 0 {
+		err = b.buildContexts(selectedContexts, projBuilders)
+	} else {
+		// build only cmake target when --target is specified
+		err = projBuilders[0].Build()
+	}
 	return err
 }
 

--- a/pkg/builder/csolution/builder_test.go
+++ b/pkg/builder/csolution/builder_test.go
@@ -262,8 +262,14 @@ func TestBuild(t *testing.T) {
 	})
 
 	t.Run("test build csolution using cbuild2cmake", func(t *testing.T) {
-		b.Options.Contexts = []string{"test.Debug+CM0"}
+		b.Options.Contexts = []string{}
 		b.Options.UseCbuild2CMake = true
+		err := b.Build()
+		assert.Error(err)
+	})
+
+	t.Run("test build csolution with target option", func(t *testing.T) {
+		b.Options.Target = "CMakeTarget"
 		err := b.Build()
 		assert.Error(err)
 	})

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -177,6 +177,7 @@ type CbuildIndex struct {
 			Project       string `json:"project"`
 			Configuration string `json:"configuration"`
 		} `yaml:"cbuilds"`
+		Executes []interface{} `yaml:"executes"`
 	} `yaml:"build-idx"`
 }
 

--- a/test/data/Test.cbuild-idx.yml
+++ b/test/data/Test.cbuild-idx.yml
@@ -19,3 +19,6 @@ build-idx:
     - cbuild: cm4/HelloWorld_cm4.Release+FRDM-K32L3A6.cbuild.yml
       project: HelloWorld_cm4
       configuration: .Release+FRDM-K32L3A6
+  executes:
+    - execute: Test
+      run: ${CMAKE_COMMAND} -E echo "Test"


### PR DESCRIPTION
Fix regression reported in https://github.com/Open-CMSIS-Pack/cbuild/issues/244
If no `--context` is specified, run cmake build target `all` to trigger `executes` steps
