### PR TITLE
Make -S,--context-set as mandatory arg for setup command

### DIFF
--- a/cmd/cbuild/commands/setup/setup.go
+++ b/cmd/cbuild/commands/setup/setup.go
@@ -72,6 +72,12 @@ func setUpProject(cmd *cobra.Command, args []string) error {
 		useCbuild2CMake = false
 	}
 
+	if !useContextSet {
+		err = errutils.New(errutils.ErrMissingRequiredArg)
+		log.Error(err)
+		return err
+	}
+
 	options := builder.Options{
 		LogFile:         logFile,
 		Generator:       generator,
@@ -137,7 +143,7 @@ func init() {
 	SetUpCmd.Flags().StringP("generator", "g", "Ninja", "Select build system generator")
 	SetUpCmd.Flags().StringSliceP("context", "c", []string{}, "Input context names [<project-name>][.<build-type>][+<target-type>]")
 	SetUpCmd.Flags().StringP("load", "l", "", "Set policy for packs loading [latest | all | required]")
-	SetUpCmd.Flags().IntP("jobs", "j", 0, "Number of job slots for parallel execution")
+	SetUpCmd.Flags().IntP("jobs", "j", 8, "Number of job slots for parallel execution")
 	SetUpCmd.Flags().StringP("target", "t", "", "Optional CMake target name")
 	SetUpCmd.Flags().BoolP("schema", "s", true, "Validate project input file(s) against schema")
 	SetUpCmd.Flags().StringP("log", "", "", "Save output messages in a log file")

--- a/cmd/cbuild/main.go
+++ b/cmd/cbuild/main.go
@@ -9,7 +9,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 
 	"github.com/Open-CMSIS-Pack/cbuild/v2/cmd/cbuild/commands"
 	log "github.com/sirupsen/logrus"
@@ -25,11 +24,7 @@ func main() {
 	cmd := commands.NewRootCmd()
 	err := cmd.Execute()
 	if err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			os.Exit(exitError.ExitCode())
-		} else {
-			os.Exit(1)
-		}
+		os.Exit(1)
 	} else {
 		os.Exit(0)
 	}

--- a/pkg/errutils/errutils.go
+++ b/pkg/errutils/errutils.go
@@ -28,7 +28,7 @@ const (
 	ErrRequireArg             = "command requires an input file argument. Run '%s' for more information about a command"
 	ErrInvalidVersionString   = "invalid version %s. Expected %s"
 	ErrInvalidNumJobs         = "invalid number of job slots specified for parallel execution. Expected: j>0"
-	ErrMissingRequiredArg     = "missing required argument. Use --context-set option"
+	ErrMissingRequiredArg     = "setup command is missing mandatory option '--context-set'"
 )
 
 const (

--- a/pkg/errutils/errutils.go
+++ b/pkg/errutils/errutils.go
@@ -28,6 +28,7 @@ const (
 	ErrRequireArg             = "command requires an input file argument. Run '%s' for more information about a command"
 	ErrInvalidVersionString   = "invalid version %s. Expected %s"
 	ErrInvalidNumJobs         = "invalid number of job slots specified for parallel execution. Expected: j>0"
+	ErrMissingRequiredArg     = "missing required argument. Use --context-set option"
 )
 
 const (


### PR DESCRIPTION
The change includes:
- Making of `-S, --context-set` argument as mandatory for setup command
- cbuild returning only error code `1` & `0` for fail and successful respectively
- Setting a default value for --jobs to 8