### PR TITLE
cpackget cleanup for version range limitation

### DIFF
--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -108,10 +108,6 @@ func (b CSolutionBuilder) installMissingPacks() (err error) {
 			continue
 		}
 
-		// This call should be removed once the limitation of 'cpackget'
-		// to handle '>=' in pack version, is resolved
-		pack = utils.RemoveVersionRange(pack)
-
 		args = []string{"add", pack, "--force-reinstall", "--agree-embedded-license", "--no-dependencies"}
 		cpackgetBin := filepath.Join(b.InstallConfigs.BinPath, "cpackget"+b.InstallConfigs.BinExtn)
 		if _, err := os.Stat(cpackgetBin); os.IsNotExist(err) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -305,18 +304,6 @@ func ResolveContexts(allContext []string, contextFilters []string) ([]string, er
 		}
 	}
 	return selectedContexts, nil
-}
-
-func RemoveVersionRange(str string) string {
-	// This function removes the version range specifier '>='
-	// from the pack version. for e.g. "ARM::CMSIS@>=6.0.0" is
-	// converted into "ARM::CMSIS@6.0.0"
-	re := regexp.MustCompile(`@([^0-9]*)(\d)`)
-	match := re.FindStringSubmatch(str)
-	if len(match) >= 3 {
-		return strings.Replace(str, match[1], "", 1)
-	}
-	return str
 }
 
 func LogStdMsg(msg string) {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -315,26 +315,6 @@ func TestResolveContexts(t *testing.T) {
 	}
 }
 
-func TestRemoveVersionRange(t *testing.T) {
-	assert := assert.New(t)
-
-	testCases := []struct {
-		inputString    string
-		expectedOutput string
-	}{
-		{"ARM::CMSIS@>=6.0.0", "ARM::CMSIS@6.0.0"},
-		{"ARM::CMSIS@>=6.0.0-alpha0", "ARM::CMSIS@6.0.0-alpha0"},
-		{"ARM::CMSIS@6.0.0", "ARM::CMSIS@6.0.0"},
-		{"ARM::CMSIS", "ARM::CMSIS"},
-		{"", ""},
-	}
-
-	for _, test := range testCases {
-		outString := RemoveVersionRange(test.inputString)
-		assert.Equal(test.expectedOutput, outString)
-	}
-}
-
 func TestRemoveDuplicates(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
This change addresses the cleanup of the patch fix that was initially introduced to accommodate cpackget's limitation of not handling '>='. Since cpackget now supports [this functionality](https://github.com/Open-CMSIS-Pack/cpackget/pull/322), the temporary fix has been removed.