### PR TITLE
Fix: cbuild  reports "bad pack name"

### DIFF
--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -92,7 +92,7 @@ func (b CSolutionBuilder) installMissingPacks() (err error) {
 	}
 
 	args := b.formulateArgs([]string{"list", "packs"})
-	args = append(args, "-m")
+	args = append(args, "-m", "-q")
 
 	// Get list of missing packs
 	output, err := b.runCSolution(args, false)


### PR DESCRIPTION
Addressing: https://github.com/Open-CMSIS-Pack/devtools/issues/1649

List pack needs to be called in quite mode in order not to list info messages