### PR TITLE
Removed redundant artifact info when packs are missing

### DIFF
--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -95,7 +95,7 @@ func (b CSolutionBuilder) installMissingPacks() (err error) {
 	args = append(args, "-m", "-q")
 
 	// Get list of missing packs
-	output, err := b.runCSolution(args, false)
+	output, err := b.runCSolution(args, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Addressing: https://github.com/Open-CMSIS-Pack/cbuild/issues/282

Now the output looks like:
```
$ cbuild Hello.csolution.yml -r -p
I: Adding pack "ARM::CMSIS-RTX@5.9.0"
Agreed to embedded license: C:\Users\soumeh01\AppData\Local\Arm\Packs\ARM\CMSIS-RTX\5.9.0\LICENSE
I: Extracting files to C:\Users\soumeh01\AppData\Local\Arm\Packs\ARM\CMSIS-RTX\5.9.0...

```