### PR TITLE
No separation lines for clean logs

### DIFF
--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -373,8 +373,10 @@ func (b CSolutionBuilder) cleanContexts(selectedContexts []string, projBuilders 
 	for index := range projBuilders {
 		progress := fmt.Sprintf("(%s/%d)", strconv.Itoa(index+1), len(projBuilders))
 		cleanMsg := progress + " Cleaning context: \"" + selectedContexts[index] + "\""
-		seplen = len(cleanMsg)
-		utils.PrintSeparator("-", seplen)
+		if seplen == 0 {
+			seplen = len(cleanMsg)
+			utils.PrintSeparator("-", seplen)
+		}
 		utils.LogStdMsg(cleanMsg)
 
 		b.setBuilderOptions(&projBuilders[index], true)


### PR DESCRIPTION
Addressing: https://github.com/Open-CMSIS-Pack/devtools/issues/1707

The output now looks like :
```
$ cbuild Hello.csolution.yml -r
+----------------------------------------
(1/2) Cleaning context: "Hello.Debug+AVH"
(2/2) Cleaning context: "Hello.Release+AVH"
+----------------------------------------
(1/2) Building context: "Hello.Debug+AVH"
Building CMake target 'Hello.Debug+AVH'
```
