### PR TITLE
Removing cbuild2cmake option and keeping it default option

### DIFF
--- a/cmd/cbuild/commands/root.go
+++ b/cmd/cbuild/commands/root.go
@@ -234,7 +234,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().BoolP("schema", "s", false, "Validate project input file(s) against schema")
 	rootCmd.PersistentFlags().StringP("log", "", "", "Save output messages in a log file")
 	rootCmd.PersistentFlags().StringP("toolchain", "", "", "Input toolchain to be used")
-	rootCmd.Flags().BoolP("cbuildgen", "", false, "Generated legacy *.cprj files and use cbuildgen backend")
+	rootCmd.Flags().BoolP("cbuildgen", "", false, "Generate legacy *.cprj files and use cbuildgen backend")
 
 	// CPRJ specific hidden flags
 	rootCmd.Flags().StringP("intdir", "i", "", "Set directory for intermediate files")

--- a/cmd/cbuild/commands/root.go
+++ b/cmd/cbuild/commands/root.go
@@ -234,8 +234,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().BoolP("schema", "s", false, "Validate project input file(s) against schema")
 	rootCmd.PersistentFlags().StringP("log", "", "", "Save output messages in a log file")
 	rootCmd.PersistentFlags().StringP("toolchain", "", "", "Input toolchain to be used")
-	rootCmd.Flags().BoolP("cbuildgen", "", false, "Use build information files with cbuildgen backend")
-	rootCmd.Flags().BoolP("cbuild2cmake", "", false, "Use build information files with cbuild2cmake backend (default)")
+	rootCmd.Flags().BoolP("cbuildgen", "", false, "Generated legacy *.cprj files and use cbuildgen backend")
 
 	// CPRJ specific hidden flags
 	rootCmd.Flags().StringP("intdir", "i", "", "Set directory for intermediate files")

--- a/cmd/cbuild/commands/setup/setup.go
+++ b/cmd/cbuild/commands/setup/setup.go
@@ -148,5 +148,5 @@ func init() {
 	SetUpCmd.Flags().BoolP("schema", "s", true, "Validate project input file(s) against schema")
 	SetUpCmd.Flags().StringP("log", "", "", "Save output messages in a log file")
 	SetUpCmd.Flags().StringP("toolchain", "", "", "Input toolchain to be used")
-	SetUpCmd.Flags().BoolP("cbuildgen", "", false, "Generated legacy *.cprj files and use cbuildgen backend")
+	SetUpCmd.Flags().BoolP("cbuildgen", "", false, "Generate legacy *.cprj files and use cbuildgen backend")
 }

--- a/cmd/cbuild/commands/setup/setup.go
+++ b/cmd/cbuild/commands/setup/setup.go
@@ -148,6 +148,5 @@ func init() {
 	SetUpCmd.Flags().BoolP("schema", "s", true, "Validate project input file(s) against schema")
 	SetUpCmd.Flags().StringP("log", "", "", "Save output messages in a log file")
 	SetUpCmd.Flags().StringP("toolchain", "", "", "Input toolchain to be used")
-	SetUpCmd.Flags().BoolP("cbuildgen", "", false, "Use build information files with cbuildgen backend")
-	SetUpCmd.Flags().BoolP("cbuild2cmake", "", false, "Use build information files with cbuild2cmake backend (default)")
+	SetUpCmd.Flags().BoolP("cbuildgen", "", false, "Generated legacy *.cprj files and use cbuildgen backend")
 }

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -148,8 +148,8 @@ func (b CSolutionBuilder) generateBuildFiles() (err error) {
 		args = append(args, "--quiet")
 	}
 
-	if b.Options.UseCbuild2CMake {
-		args = append(args, "--cbuild2cmake")
+	if !b.Options.UseCbuild2CMake {
+		args = append(args, "--cbuildgen")
 	}
 
 	var stdErr string


### PR DESCRIPTION
Addressing partially : https://github.com/Open-CMSIS-Pack/devtools/issues/1700

As part of this PR:
- Removed the `--cbuild2cmake` option.
- Introduced the `--cbuildgen` option.

**Note:** The native CMake-based build approach will now be the default, without requiring an explicit option.