### PR TITLE
[cbuild] Restore cbuild setup `--output` option

### DIFF
--- a/cmd/cbuild/commands/setup/setup.go
+++ b/cmd/cbuild/commands/setup/setup.go
@@ -54,6 +54,7 @@ func setUpProject(cmd *cobra.Command, args []string) error {
 	contexts, _ := cmd.Flags().GetStringSlice("context")
 	load, _ := cmd.Flags().GetString("load")
 	jobs, _ := cmd.Flags().GetInt("jobs")
+	output, _ := cmd.Flags().GetString("output")
 	quiet, _ := cmd.Flags().GetBool("quiet")
 	debug, _ := cmd.Flags().GetBool("debug")
 	verbose, _ := cmd.Flags().GetBool("verbose")
@@ -94,6 +95,7 @@ func setUpProject(cmd *cobra.Command, args []string) error {
 		Contexts:        contexts,
 		UseContextSet:   useContextSet,
 		Load:            load,
+		Output:          output,
 		Toolchain:       toolchain,
 		FrozenPacks:     frozenPacks,
 		UseCbuild2CMake: useCbuild2CMake,
@@ -145,6 +147,7 @@ func init() {
 	SetUpCmd.Flags().StringP("load", "l", "", "Set policy for packs loading [latest | all | required]")
 	SetUpCmd.Flags().IntP("jobs", "j", 8, "Number of job slots for parallel execution")
 	SetUpCmd.Flags().StringP("target", "t", "", "Optional CMake target name")
+	SetUpCmd.Flags().StringP("output", "O", "", "Add prefix to 'outdir' and 'tmpdir'")
 	SetUpCmd.Flags().BoolP("schema", "s", true, "Validate project input file(s) against schema")
 	SetUpCmd.Flags().StringP("log", "", "", "Save output messages in a log file")
 	SetUpCmd.Flags().StringP("toolchain", "", "", "Input toolchain to be used")

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -279,8 +279,13 @@ func (b CSolutionBuilder) getProjectName(csolutionFile string) (projectName stri
 // It is the caller's responsibility to verify if the file exists."
 func (b CSolutionBuilder) getCbuildSetFilePath() string {
 	projName := b.getProjectName(b.InputFile)
-	setFilePath := utils.NormalizePath(filepath.Join(filepath.Dir(b.InputFile), projName+".cbuild-set.yml"))
-	return setFilePath
+	var cbuildSetDir string
+	if len(b.Options.Output) > 0 {
+		cbuildSetDir = b.Options.Output
+	} else {
+		cbuildSetDir = filepath.Dir(b.InputFile)
+	}
+	return utils.NormalizePath(filepath.Join(cbuildSetDir, projName+".cbuild-set.yml"))
 }
 
 func (b CSolutionBuilder) getProjsBuilders(selectedContexts []string) (projBuilders []builder.IBuilderInterface, err error) {

--- a/pkg/builder/csolution/builder_test.go
+++ b/pkg/builder/csolution/builder_test.go
@@ -488,6 +488,13 @@ func TestGetCbuildSetFilePath(t *testing.T) {
 		path := b.getCbuildSetFilePath()
 		assert.Equal(path, utils.NormalizePath(filepath.Join(testRoot, testDir, "TestSolution/test.cbuild-set.yml")))
 	})
+
+	t.Run("test get cbuild-set file path with output option", func(t *testing.T) {
+		b.InputFile = filepath.Join(testRoot, testDir, "TestSolution/test.csolution.yml")
+		b.Options.Output = "OutOfTree"
+		path := b.getCbuildSetFilePath()
+		assert.Equal(path, utils.NormalizePath("OutOfTree/test.cbuild-set.yml"))
+	})
 }
 
 func TestHasRebuildNode(t *testing.T) {


### PR DESCRIPTION
Address https://github.com/Open-CMSIS-Pack/devtools/issues/1747
Fix cbuild-set location when `--output` is specified - https://github.com/Arm-Debug/devtools-external/pull/1023