### PR TITLE
[cbuild] Rework `csolution list layers` arguments in `cbuild setup` background call

### DIFF
--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -175,7 +175,11 @@ func (b CSolutionBuilder) generateBuildFiles() (err error) {
 			log.Debug("error code received: " + errCodeStr)
 
 			if exitError.ExitCode() == 2 {
-				args = []string{"list", "layers", b.InputFile, "--context-set", "--load=all", "--update-idx", "--quiet"}
+				args = b.formulateArgs([]string{"list", "layers", "--update-idx"})
+				if !b.Options.Quiet {
+					// force --quiet
+					args = append(args, "--quiet")
+				}
 				_, listCmdErr := b.runCSolution(args, false)
 				log.Debug("csolution command: csolution " + strings.Join(args, " "))
 				if listCmdErr != nil {


### PR DESCRIPTION
Address https://github.com/Open-CMSIS-Pack/devtools/issues/1760

In the background `csolution list layers` call, remove the fixed `--load=all` argument.
Take the arguments from the original `cbuild setup` call if specified.