### PR TITLE
[cbuild] Remove special handling for triggering `executes` steps

### DIFF
--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -433,18 +433,6 @@ func (b CSolutionBuilder) buildContexts(selectedContexts []string, projBuilders 
 	if !b.Setup {
 		buildSummary := fmt.Sprintf("Build summary: %d succeeded, %d failed - Time Elapsed: %s", buildPassCnt, buildFailCnt, utils.FormatTime(totalBuildTime))
 		sepLen := len(buildSummary)
-		// if no context is specified, run cmake build target 'all' to trigger 'executes' steps
-		if b.Options.UseCbuild2CMake && len(b.Options.Contexts) == 0 && projBuilders[0].(cbuildidx.CbuildIdxBuilder).HasExecutes() {
-			infoMsg := "Check all CMake targets"
-			sepLen := len(infoMsg)
-			utils.PrintSeparator("-", sepLen)
-			utils.LogStdMsg(infoMsg)
-			builder := projBuilders[0].(cbuildidx.CbuildIdxBuilder)
-			builder.Options.Target = "all"
-			if buildErr := builder.Build(); buildErr != nil {
-				err = buildErr
-			}
-		}
 		utils.PrintSeparator("-", sepLen)
 		utils.LogStdMsg(buildSummary)
 		utils.PrintSeparator("=", sepLen)


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->

- Align with https://github.com/Open-CMSIS-Pack/cbuild2cmake/pull/225

## Changes
<!-- List the changes this PR introduces -->

- After https://github.com/Open-CMSIS-Pack/cbuild2cmake/pull/225 it's not needed to call `cmake --target all` for triggering all relevant `executes` steps, including those executed post build.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [ ] 🤖 This change is covered by unit tests as required.
- [ ] 🤹 All required manual testing has been performed.
- [ ] 🛡️ Security impacts have been considered.
- [ ] 📖 All documentation updates are complete.
- [ ] 🧠 This change does not change third-party dependencies
