### PR TITLE
Enable default schema check and deprecate -s

### DIFF
--- a/cmd/cbuild/commands/build/buildcprj.go
+++ b/cmd/cbuild/commands/build/buildcprj.go
@@ -43,7 +43,7 @@ func BuildCPRJ(cmd *cobra.Command, args []string) error {
 	debug, _ := cmd.Flags().GetBool("debug")
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	clean, _ := cmd.Flags().GetBool("clean")
-	schema, _ := cmd.Flags().GetBool("schema")
+	schemaChk, _ := cmd.Flags().GetBool("no-schema-check")
 	packs, _ := cmd.Flags().GetBool("packs")
 	rebuild, _ := cmd.Flags().GetBool("rebuild")
 	updateRte, _ := cmd.Flags().GetBool("update-rte")
@@ -61,7 +61,7 @@ func BuildCPRJ(cmd *cobra.Command, args []string) error {
 		Debug:     debug,
 		Verbose:   verbose,
 		Clean:     clean,
-		Schema:    schema,
+		SchemaChk: !schemaChk,
 		Packs:     packs,
 		Rebuild:   rebuild,
 		UpdateRte: updateRte,
@@ -121,7 +121,8 @@ func init() {
 	BuildCPRJCmd.Flags().BoolP("packs", "p", false, "Download missing software packs with cpackget")
 	BuildCPRJCmd.Flags().BoolP("rebuild", "r", false, "Remove intermediate and output directories and rebuild")
 	BuildCPRJCmd.Flags().BoolP("update-rte", "", false, "Update the RTE directory and files")
-	BuildCPRJCmd.Flags().BoolP("schema", "s", false, "Validate project input file(s) against schema")
+	BuildCPRJCmd.Flags().BoolP("schema", "s", false, "Validate project input file(s) against schema [deprecated]")
+	BuildCPRJCmd.Flags().BoolP("no-schema-check", "n", false, "Skip schema check")
 	BuildCPRJCmd.Flags().StringP("target", "t", "", "Optional CMake target name")
 	BuildCPRJCmd.Flags().StringP("log", "", "", "Save output messages in a log file")
 	BuildCPRJCmd.Flags().StringP("toolchain", "", "", "Input toolchain to be used")

--- a/cmd/cbuild/commands/list/list_contexts.go
+++ b/cmd/cbuild/commands/list/list_contexts.go
@@ -47,13 +47,13 @@ func listContexts(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	schemaChk, _ := cmd.Flags().GetBool("no-schema-check")
+	noSchemaChk, _ := cmd.Flags().GetBool("no-schema-check")
 	filter, _ := cmd.Flags().GetString("filter")
 	p := csolution.CSolutionBuilder{
 		BuilderParams: builder.BuilderParams{
 			Runner: utils.Runner{},
 			Options: builder.Options{
-				SchemaChk: !schemaChk,
+				SchemaChk: !noSchemaChk,
 				Filter:    filter,
 			},
 			InputFile:      args[0],

--- a/cmd/cbuild/commands/list/list_contexts.go
+++ b/cmd/cbuild/commands/list/list_contexts.go
@@ -47,14 +47,14 @@ func listContexts(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	schemaCheck, _ := cmd.Flags().GetBool("schema")
+	schemaChk, _ := cmd.Flags().GetBool("no-schema-check")
 	filter, _ := cmd.Flags().GetString("filter")
 	p := csolution.CSolutionBuilder{
 		BuilderParams: builder.BuilderParams{
 			Runner: utils.Runner{},
 			Options: builder.Options{
-				Schema: schemaCheck,
-				Filter: filter,
+				SchemaChk: !schemaChk,
+				Filter:    filter,
 			},
 			InputFile:      args[0],
 			InstallConfigs: configs,

--- a/cmd/cbuild/commands/root.go
+++ b/cmd/cbuild/commands/root.go
@@ -133,7 +133,7 @@ func NewRootCmd() *cobra.Command {
 			debug, _ := cmd.Flags().GetBool("debug")
 			verbose, _ := cmd.Flags().GetBool("verbose")
 			clean, _ := cmd.Flags().GetBool("clean")
-			schemaChk, _ := cmd.Flags().GetBool("no-schema-check")
+			noSchemaChk, _ := cmd.Flags().GetBool("noSchemaCheck")
 			packs, _ := cmd.Flags().GetBool("packs")
 			rebuild, _ := cmd.Flags().GetBool("rebuild")
 			updateRte, _ := cmd.Flags().GetBool("update-rte")
@@ -166,7 +166,7 @@ func NewRootCmd() *cobra.Command {
 				Debug:           debug,
 				Verbose:         verbose,
 				Clean:           clean,
-				SchemaChk:       !schemaChk,
+				SchemaChk:       !noSchemaChk,
 				Packs:           packs,
 				Rebuild:         rebuild,
 				UpdateRte:       updateRte,

--- a/cmd/cbuild/commands/root.go
+++ b/cmd/cbuild/commands/root.go
@@ -133,7 +133,7 @@ func NewRootCmd() *cobra.Command {
 			debug, _ := cmd.Flags().GetBool("debug")
 			verbose, _ := cmd.Flags().GetBool("verbose")
 			clean, _ := cmd.Flags().GetBool("clean")
-			schema, _ := cmd.Flags().GetBool("schema")
+			schemaChk, _ := cmd.Flags().GetBool("no-schema-check")
 			packs, _ := cmd.Flags().GetBool("packs")
 			rebuild, _ := cmd.Flags().GetBool("rebuild")
 			updateRte, _ := cmd.Flags().GetBool("update-rte")
@@ -166,7 +166,7 @@ func NewRootCmd() *cobra.Command {
 				Debug:           debug,
 				Verbose:         verbose,
 				Clean:           clean,
-				Schema:          schema,
+				SchemaChk:       !schemaChk,
 				Packs:           packs,
 				Rebuild:         rebuild,
 				UpdateRte:       updateRte,
@@ -235,7 +235,8 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.Flags().IntP("jobs", "j", 8, "Number of job slots for parallel execution")
 	rootCmd.Flags().StringP("target", "t", "", "Optional CMake target name")
 	rootCmd.Flags().StringP("output", "O", "", "Add prefix to 'outdir' and 'tmpdir'")
-	rootCmd.PersistentFlags().BoolP("schema", "s", false, "Validate project input file(s) against schema")
+	rootCmd.PersistentFlags().BoolP("schema", "s", false, "Validate project input file(s) against schema [deprecated]")
+	rootCmd.PersistentFlags().BoolP("no-schema-check", "n", false, "Skip schema check")
 	rootCmd.PersistentFlags().StringP("log", "", "", "Save output messages in a log file")
 	rootCmd.PersistentFlags().StringP("toolchain", "", "", "Input toolchain to be used")
 	rootCmd.Flags().BoolP("cbuildgen", "", false, "Generate legacy *.cprj files and use cbuildgen backend")

--- a/cmd/cbuild/commands/setup/setup.go
+++ b/cmd/cbuild/commands/setup/setup.go
@@ -59,7 +59,7 @@ func setUpProject(cmd *cobra.Command, args []string) error {
 	debug, _ := cmd.Flags().GetBool("debug")
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	clean, _ := cmd.Flags().GetBool("clean")
-	schema, _ := cmd.Flags().GetBool("schema")
+	schemaChk, _ := cmd.Flags().GetBool("no-schema-check")
 	packs, _ := cmd.Flags().GetBool("packs")
 	rebuild, _ := cmd.Flags().GetBool("rebuild")
 	updateRte, _ := cmd.Flags().GetBool("update-rte")
@@ -89,7 +89,7 @@ func setUpProject(cmd *cobra.Command, args []string) error {
 		Debug:           debug,
 		Verbose:         verbose,
 		Clean:           clean,
-		Schema:          schema,
+		SchemaChk:       !schemaChk,
 		Packs:           packs,
 		Rebuild:         rebuild,
 		UpdateRte:       updateRte,
@@ -150,7 +150,8 @@ func init() {
 	SetUpCmd.Flags().IntP("jobs", "j", 8, "Number of job slots for parallel execution")
 	SetUpCmd.Flags().StringP("target", "t", "", "Optional CMake target name")
 	SetUpCmd.Flags().StringP("output", "O", "", "Add prefix to 'outdir' and 'tmpdir'")
-	SetUpCmd.Flags().BoolP("schema", "s", true, "Validate project input file(s) against schema")
+	SetUpCmd.Flags().BoolP("schema", "s", true, "Validate project input file(s) against schema [deprecated]")
+	SetUpCmd.Flags().BoolP("no-schema-check", "n", false, "Skip schema check")
 	SetUpCmd.Flags().StringP("log", "", "", "Save output messages in a log file")
 	SetUpCmd.Flags().StringP("toolchain", "", "", "Input toolchain to be used")
 	SetUpCmd.Flags().BoolP("cbuildgen", "", false, "Generate legacy *.cprj files and use cbuildgen backend")

--- a/pkg/builder/cproject/builder.go
+++ b/pkg/builder/cproject/builder.go
@@ -129,7 +129,7 @@ func (b CprjBuilder) build() error {
 		return err
 	}
 
-	if b.Options.Schema {
+	if b.Options.SchemaChk {
 		if vars.XmllintBin == "" {
 			log.Warn("xmllint was not found, proceed without xml validation")
 		} else {

--- a/pkg/builder/cproject/builder_test.go
+++ b/pkg/builder/cproject/builder_test.go
@@ -210,7 +210,6 @@ func TestBuild(t *testing.T) {
 	})
 
 	t.Run("test build cprj schema check", func(t *testing.T) {
-		b.Options.Schema = true
 		err := b.Build()
 		assert.Nil(err)
 	})

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -43,7 +43,7 @@ func (b CSolutionBuilder) formulateArgs(command []string) (args []string) {
 	if b.Options.Load != "" {
 		args = append(args, "--load="+b.Options.Load)
 	}
-	if !b.Options.Schema {
+	if !b.Options.SchemaChk {
 		args = append(args, "--no-check-schema")
 	}
 	if !b.Options.UpdateRte {
@@ -296,8 +296,8 @@ func (b CSolutionBuilder) getProjsBuilders(selectedContexts []string) (projBuild
 	buildOptions := b.Options
 
 	// Set XML schema check to false, when input is yml
-	if b.Options.Schema {
-		buildOptions.Schema = false
+	if b.Options.SchemaChk {
+		buildOptions.SchemaChk = false
 	}
 
 	idxFile, err := b.getIdxFilePath()

--- a/pkg/builder/csolution/builder_test.go
+++ b/pkg/builder/csolution/builder_test.go
@@ -110,7 +110,6 @@ func TestListContexts(t *testing.T) {
 	})
 
 	t.Run("test list contexts with schema check", func(t *testing.T) {
-		b.Options.Schema = true
 		contexts, err := b.listContexts(true, false)
 		assert.Nil(err)
 		assert.Equal(len(contexts), 2)
@@ -176,7 +175,6 @@ func TestListToolchians(t *testing.T) {
 	})
 
 	t.Run("test list toochains with schema check", func(t *testing.T) {
-		b.Options.Schema = true
 		toolchains, err := b.listToolchains(true)
 		assert.Nil(err)
 		assert.Equal(len(toolchains), 4)

--- a/pkg/builder/interface.go
+++ b/pkg/builder/interface.go
@@ -41,7 +41,7 @@ type Options struct {
 	Debug           bool
 	Verbose         bool
 	Clean           bool
-	Schema          bool
+	SchemaChk       bool
 	Packs           bool
 	Rebuild         bool
 	UpdateRte       bool


### PR DESCRIPTION
## Fixes
- Addressing https://github.com/Open-CMSIS-Pack/devtools/issues/1777

## Changes
- Deprecation of `-s` option
- Enabled default schema check
- Added new option to disable schema check `-n,--no-schema-check`

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by unit tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 🛡️ Security impacts have been considered.
- [x] 📖 All documentation updates are complete.
- [x] 🧠 This change does not change third-party dependencies
