### PR TITLE
Avoid double schema check on setup command

### DIFF
--- a/cmd/cbuild/commands/build/buildcprj.go
+++ b/cmd/cbuild/commands/build/buildcprj.go
@@ -43,7 +43,7 @@ func BuildCPRJ(cmd *cobra.Command, args []string) error {
 	debug, _ := cmd.Flags().GetBool("debug")
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	clean, _ := cmd.Flags().GetBool("clean")
-	schemaChk, _ := cmd.Flags().GetBool("no-schema-check")
+	noSchemaChk, _ := cmd.Flags().GetBool("no-schema-check")
 	packs, _ := cmd.Flags().GetBool("packs")
 	rebuild, _ := cmd.Flags().GetBool("rebuild")
 	updateRte, _ := cmd.Flags().GetBool("update-rte")
@@ -61,7 +61,7 @@ func BuildCPRJ(cmd *cobra.Command, args []string) error {
 		Debug:     debug,
 		Verbose:   verbose,
 		Clean:     clean,
-		SchemaChk: !schemaChk,
+		SchemaChk: !noSchemaChk,
 		Packs:     packs,
 		Rebuild:   rebuild,
 		UpdateRte: updateRte,

--- a/cmd/cbuild/commands/setup/setup.go
+++ b/cmd/cbuild/commands/setup/setup.go
@@ -59,7 +59,7 @@ func setUpProject(cmd *cobra.Command, args []string) error {
 	debug, _ := cmd.Flags().GetBool("debug")
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	clean, _ := cmd.Flags().GetBool("clean")
-	schemaChk, _ := cmd.Flags().GetBool("no-schema-check")
+	noSchemaChk, _ := cmd.Flags().GetBool("no-schema-check")
 	packs, _ := cmd.Flags().GetBool("packs")
 	rebuild, _ := cmd.Flags().GetBool("rebuild")
 	updateRte, _ := cmd.Flags().GetBool("update-rte")
@@ -89,7 +89,7 @@ func setUpProject(cmd *cobra.Command, args []string) error {
 		Debug:           debug,
 		Verbose:         verbose,
 		Clean:           clean,
-		SchemaChk:       !schemaChk,
+		SchemaChk:       !noSchemaChk,
 		Packs:           packs,
 		Rebuild:         rebuild,
 		UpdateRte:       updateRte,

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -94,6 +94,13 @@ func (b CSolutionBuilder) installMissingPacks() (err error) {
 	args := b.formulateArgs([]string{"list", "packs"})
 	args = append(args, "-m", "-q")
 
+	if b.Setup {
+		// If the setup command is triggered, skip the schema check when retrieving the list of missing packs.
+		// This is because the schema check will be performed later during the YAML generation step.
+		// Skipping it here avoids redundant checks and prevents potential double schema check errors.
+		args = append(args, "-n")
+	}
+
 	// Get list of missing packs
 	output, err := b.runCSolution(args, true)
 	if err != nil {


### PR DESCRIPTION
## Fixes
- https://github.com/Open-CMSIS-Pack/devtools/issues/1853

## Changes
- Renaming the variables aligning with option
- skip schema check on `list packs` when `setup `command is triggered

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [ ] 🤖 This change is covered by unit tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 🛡️ Security impacts have been considered.
- [x] 📖 All documentation updates are complete.
- [x] 🧠 This change does not change third-party dependencies
