### PR TITLE
Correction in naming of option

### DIFF
--- a/cmd/cbuild/commands/root.go
+++ b/cmd/cbuild/commands/root.go
@@ -133,7 +133,7 @@ func NewRootCmd() *cobra.Command {
 			debug, _ := cmd.Flags().GetBool("debug")
 			verbose, _ := cmd.Flags().GetBool("verbose")
 			clean, _ := cmd.Flags().GetBool("clean")
-			noSchemaChk, _ := cmd.Flags().GetBool("noSchemaCheck")
+			noSchemaChk, _ := cmd.Flags().GetBool("no-schema-check")
 			packs, _ := cmd.Flags().GetBool("packs")
 			rebuild, _ := cmd.Flags().GetBool("rebuild")
 			updateRte, _ := cmd.Flags().GetBool("update-rte")


### PR DESCRIPTION
## Changes
- Corrected naming from residual of other changes

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [ ] 🤖 This change is covered by unit tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 🛡️ Security impacts have been considered.
- [ ] 📖 All documentation updates are complete.
- [x] 🧠 This change does not change third-party dependencies
