### PR TITLE
Linter updates and configuration migration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,11 +44,10 @@ jobs:
             **/go.mod
             **/go.sum
 
-      - uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
+      - uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
           version: latest
           skip-cache: true
-          args: "--verbose --print-issued-lines --print-linter-name --out-${NO_FUTURE}format colored-line-number --timeout 300s --max-issues-per-linter 0 --max-same-issues 0"
 
   format:
     name: Format

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,3 +19,7 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,22 +1,21 @@
+version: "2"
 run:
-  timeout: 10m
-
-  # Run linters over integration tests
   build-tags:
     - integration
-
 linters:
-  disable-all: true # Disable defaults, then enable the ones we want
+  default: none
   enable:
+    - bodyclose
     - errcheck
-    - gosimple
+    - gosec
     - govet
     - ineffassign
     - staticcheck
-    - typecheck
     - unused
-    - bodyclose
-    - stylecheck
-    - gosec
-    - goimports
-    - gofmt
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling

--- a/cmd/cbuild/commands/build/buildcprj.go
+++ b/cmd/cbuild/commands/build/buildcprj.go
@@ -19,13 +19,14 @@ import (
 func BuildCPRJ(cmd *cobra.Command, args []string) error {
 	var inputFile string
 	argCnt := len(args)
-	if argCnt == 0 {
+	switch argCnt {
+	case 0:
 		err := errutils.New(errutils.ErrRequireArg, "cbuild buildcprj --help")
 		log.Error(err)
 		return err
-	} else if argCnt == 1 {
+	case 1:
 		inputFile = args[0]
-	} else {
+	default:
 		err := errutils.New(errutils.ErrInvalidCmdLineArg)
 		log.Error(err)
 		_ = cmd.Help()

--- a/cmd/cbuild/commands/list/list_contexts.go
+++ b/cmd/cbuild/commands/list/list_contexts.go
@@ -20,11 +20,12 @@ import (
 func listContexts(cmd *cobra.Command, args []string) error {
 	var inputFile string
 	argCnt := len(args)
-	if argCnt == 0 {
+	switch argCnt {
+	case 0:
 		return errutils.New(errutils.ErrRequireArg, "cbuild list contexts --help")
-	} else if argCnt == 1 {
+	case 1:
 		inputFile = args[0]
-	} else {
+	default:
 		err := errutils.New(errutils.ErrInvalidCmdLineArg)
 		log.Error(err)
 		_ = cmd.Help()

--- a/cmd/cbuild/commands/root.go
+++ b/cmd/cbuild/commands/root.go
@@ -143,10 +143,7 @@ func NewRootCmd() *cobra.Command {
 			useCbuildgen, _ := cmd.Flags().GetBool("cbuildgen")
 
 			// set cbuild2cmake as default tool
-			useCbuild2CMake := true
-			if useCbuildgen {
-				useCbuild2CMake = false
-			}
+			useCbuild2CMake := !useCbuildgen
 
 			if jobs <= 0 {
 				err := errutils.New(errutils.ErrInvalidNumJobs)
@@ -229,7 +226,7 @@ func NewRootCmd() *cobra.Command {
 	}
 
 	cobra.AddTemplateFunc("replaceString", func(s string) string {
-		return strings.Replace(strings.Replace(s, "strings  ", "arg [...]", -1), "string ", "arg    ", -1)
+		return strings.ReplaceAll(strings.ReplaceAll(s, "strings  ", "arg [...]"), "string ", "arg    ")
 	})
 	rootCmd.SetUsageTemplate(usageTemplate)
 	rootCmd.DisableFlagsInUseLine = true

--- a/cmd/cbuild/commands/setup/setup.go
+++ b/cmd/cbuild/commands/setup/setup.go
@@ -22,13 +22,14 @@ import (
 func setUpProject(cmd *cobra.Command, args []string) error {
 	var inputFile string
 	argCnt := len(args)
-	if argCnt == 0 {
+	switch argCnt {
+	case 0:
 		err := errutils.New(errutils.ErrRequireArg, "cbuild setup --help")
 		log.Error(err)
 		return err
-	} else if argCnt == 1 {
+	case 1:
 		inputFile = args[0]
-	} else {
+	default:
 		err := errutils.New(errutils.ErrInvalidCmdLineArg)
 		log.Error(err)
 		_ = cmd.Help()
@@ -71,10 +72,7 @@ func setUpProject(cmd *cobra.Command, args []string) error {
 	useCbuildgen, _ := cmd.Flags().GetBool("cbuildgen")
 	noDatabase, _ := cmd.Flags().GetBool("no-database")
 
-	useCbuild2CMake := true
-	if useCbuildgen {
-		useCbuild2CMake = false
-	}
+	useCbuild2CMake := !useCbuildgen
 
 	if !useContextSet {
 		err = errutils.New(errutils.ErrMissingRequiredArg)

--- a/pkg/builder/cbuildidx/builder.go
+++ b/pkg/builder/cbuildidx/builder.go
@@ -139,6 +139,7 @@ func (b CbuildIdxBuilder) build() error {
 		log.Debug("cbuild2cmake command: " + vars.Cbuild2cmakeBin + " " + strings.Join(args, " "))
 	}
 
+	//nolint:staticcheck // intentional logic for clarity
 	_, err = b.Runner.ExecuteCommand(vars.Cbuild2cmakeBin, !(b.Options.Debug || b.Options.Verbose), args...)
 	if err != nil {
 		return err
@@ -167,6 +168,7 @@ func (b CbuildIdxBuilder) build() error {
 		log.Debug("cmake configuration command: " + vars.CmakeBin + " " + strings.Join(args, " "))
 	}
 
+	//nolint:staticcheck // intentional logic for clarity
 	_, err = b.Runner.ExecuteCommand(vars.CmakeBin, !(b.Options.Debug || b.Options.Verbose), args...)
 	if err != nil {
 		return err
@@ -186,6 +188,7 @@ func (b CbuildIdxBuilder) build() error {
 		args = append(args, "--target", buildTarget)
 	}
 
+	//nolint:staticcheck // intentional logic for clarity
 	if b.Options.Generator == "Ninja" && !(b.Options.Debug || b.Options.Verbose) {
 		isVersionGreaterorEqual, err := b.validateNinjaVersion(NinjaVersion)
 		if err != nil {

--- a/pkg/builder/cproject/builder_test.go
+++ b/pkg/builder/cproject/builder_test.go
@@ -30,11 +30,12 @@ type RunnerMock struct{}
 
 func (r RunnerMock) ExecuteCommand(program string, quiet bool, args ...string) (string, error) {
 	if strings.Contains(program, "cbuildgen") {
-		if args[0] == "packlist" {
+		switch args[0] {
+		case "packlist":
 			packlistFile := filepath.Join(testRoot, testDir, "IntDir/minimal.cpinstall")
 			file, _ := os.Create(packlistFile)
 			defer file.Close()
-		} else if args[0] == "cmake" {
+		case "cmake":
 			cmakelistFile := filepath.Join(testRoot, testDir, "IntDir/CMakeLists.txt")
 			file, _ := os.Create(cmakelistFile)
 			defer file.Close()

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -168,6 +168,7 @@ func (b CSolutionBuilder) generateBuildFiles() (err error) {
 		}
 		_, stdErr, err = utils.ExecuteCommand(csolutionBin, args...)
 	} else {
+		//nolint:staticcheck // intentional logic for clarity
 		_, err = b.runCSolution(args, !(b.Options.Debug || b.Options.Verbose))
 	}
 

--- a/pkg/builder/csolution/builder_test.go
+++ b/pkg/builder/csolution/builder_test.go
@@ -33,17 +33,19 @@ type RunnerMock struct{}
 
 func (r RunnerMock) ExecuteCommand(program string, quiet bool, args ...string) (string, error) {
 	if strings.Contains(program, "csolution") {
-		if args[0] == "list" {
-			if args[1] == "contexts" {
+		switch args[0] {
+		case "list":
+			switch args[1] {
+			case "contexts":
 				return "test.Debug+CM0\r\ntest.Release+CM0", nil
-			} else if args[1] == "toolchains" {
+			case "toolchains":
 				return "AC5@5.6.7\nAC6@6.18.0\nGCC@11.2.1\nIAR@8.50.6\n", nil
-			} else if args[1] == "packs" {
+			case "packs":
 				return "ARM::test:0.0.1\r\nARM::test2:0.0.2", nil
-			} else if args[1] == "environment" {
+			case "environment":
 				return "CMSIS_PACK_ROOT=C:/Path/Packs\nCMSIS_COMPILER_ROOT=C:/Test/etc\n", nil
 			}
-		} else if args[0] == "convert" {
+		case "convert":
 			return "", nil
 		}
 	} else if strings.Contains(program, "cbuildgen") {


### PR DESCRIPTION
## Fixes
- Updated version of linter and migrated configuration to latest
- The new version of linter has megred many tools into one resulted in more checks than before. Hence there are new findings in the code and updates were required for. e.g The linters stylecheck, gosimple, and staticcheck has been merged inside the staticcheck.
- Changes are listed under https://golangci-lint.run/product/migration-guide/


## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
