### PR TITLE
Irrelevant Error Message When Compiler Registration Variable Is Missing

### DIFF
--- a/pkg/errutils/errutils.go
+++ b/pkg/errutils/errutils.go
@@ -34,6 +34,7 @@ const (
 	ErrFetchingAbsPath        = "unable to get absolute path: '%s'"
 	ErrInvalidPath            = "invalid path: '%s'"
 	ErrPerfResults            = "unable to save performance results: %s"
+	ErrNoCompilerRegistered   = "required compiler(s) not registered: '%s'"
 )
 
 const (

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -180,6 +180,10 @@ type CbuildIndex struct {
 			Project       string `yaml:"project"`
 			Configuration string `yaml:"configuration"`
 			Rebuild       bool   `yaml:"rebuild"`
+			Messages      struct {
+				Warnings []string `yaml:"warnings"`
+				Info     []string `yaml:"info"`
+			} `yaml:"messages"`
 		} `yaml:"cbuilds"`
 		Executes []interface{} `yaml:"executes"`
 		Rebuild  bool          `yaml:"rebuild"`


### PR DESCRIPTION
## Fixes
- https://github.com/Open-CMSIS-Pack/devtools/issues/2032

## Changes
As part of this change, missing toolchain registration will result in an error.
```
$ cbuild ./solution.csolution.yml --update-rte -r
warning cbuild: path does not exist: 'tmp'
+--------------------------------------------
(1/4) Cleaning context: "project.AC6+ARMCM55"
warning cbuild: path does not exist: 'out'
(2/4) Cleaning context: "project.GCC+ARMCM55"
warning cbuild: path does not exist: 'out\project\ARMCM55\GCC'
(3/4) Cleaning context: "project.IAR+ARMCM55"
warning cbuild: path does not exist: 'out'
(4/4) Cleaning context: "project.CLANG+ARMCM55"
warning cbuild: path does not exist: 'out'
warning csolution: no compiler registered for 'GCC'. Add path to compiler 'bin' directory with environment variable GCC_TOOLCHAIN_<major>_<minor>_<patch>
warning csolution: no compiler registered for 'IAR'. Add path to compiler 'bin' directory with environment variable IAR_TOOLCHAIN_<major>_<minor>_<patch>
error cbuild: required compiler(s) not registered: 'GCC, IAR'

```

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
