### PR TITLE
Extended command line options with -a, --active

### DIFF
--- a/cmd/cbuild/commands/root.go
+++ b/cmd/cbuild/commands/root.go
@@ -141,9 +141,17 @@ func NewRootCmd() *cobra.Command {
 			useContextSet, _ := cmd.Flags().GetBool("context-set")
 			frozenPacks, _ := cmd.Flags().GetBool("frozen-packs")
 			useCbuildgen, _ := cmd.Flags().GetBool("cbuildgen")
+			targetSet, _ := cmd.Flags().GetString("active")
 
 			// set cbuild2cmake as default tool
 			useCbuild2CMake := !useCbuildgen
+
+			// -a option is not compatible with -c or -S
+			if targetSet != "" && (len(contexts) > 0 || useContextSet) {
+				err := errutils.New(errutils.ErrInvalidTargetSetUsage)
+				log.Error(err)
+				return err
+			}
 
 			if jobs <= 0 {
 				err := errutils.New(errutils.ErrInvalidNumJobs)
@@ -174,6 +182,7 @@ func NewRootCmd() *cobra.Command {
 				Toolchain:       toolchain,
 				FrozenPacks:     frozenPacks,
 				UseCbuild2CMake: useCbuild2CMake,
+				TargetSet:       targetSet,
 			}
 
 			configs, err := utils.GetInstallConfigs()
@@ -254,6 +263,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().StringP("log", "", "", "Save output messages in a log file")
 	rootCmd.PersistentFlags().StringP("toolchain", "", "", "Input toolchain to be used")
 	rootCmd.Flags().BoolP("cbuildgen", "", false, "Generate legacy *.cprj files and use cbuildgen backend")
+	rootCmd.Flags().StringP("active", "a", "", "Select active target-set: <target-type>[@<set>]")
 
 	// CPRJ specific hidden flags
 	rootCmd.Flags().StringP("intdir", "i", "", "Set directory for intermediate files")

--- a/cmd/cbuild/commands/root_test.go
+++ b/cmd/cbuild/commands/root_test.go
@@ -71,6 +71,32 @@ func TestCommands(t *testing.T) {
 		err := cmd.Execute()
 		assert.Error(err)
 	})
+
+	t.Run("test invalid command with -a and -c", func(t *testing.T) {
+		cmd := commands.NewRootCmd()
+		cmd.SetArgs([]string{csolutionFile, "-a", "test", "-c", "test.Debug+CM0"})
+
+		err := cmd.Execute()
+		assert.EqualError(err, "invalid target-set usage. The '-a' option cannot be used with the '-c' or '-S'")
+	})
+
+	t.Run("test invalid command with -a and -S", func(t *testing.T) {
+		cmd := commands.NewRootCmd()
+		cmd.SetArgs([]string{csolutionFile, "-a", "test", "-S"})
+
+		err := cmd.Execute()
+		assert.EqualError(err, "invalid target-set usage. The '-a' option cannot be used with the '-c' or '-S'")
+	})
+
+	t.Run("test valid command with -a", func(t *testing.T) {
+		cmd := commands.NewRootCmd()
+		cmd.SetArgs([]string{csolutionFile, "-a", "test"})
+
+		err := cmd.Execute()
+		// Though the command is valid, It fails for other reasons
+		assert.Error(err)
+		assert.Contains(err.Error(), "couldn't locate '../etc' directory relative to")
+	})
 }
 
 func TestPreLogConfiguration(t *testing.T) {

--- a/cmd/cbuild/commands/root_test.go
+++ b/cmd/cbuild/commands/root_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024 Arm Limited. All rights reserved.
+ * Copyright (c) 2022-2025 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/cmd/cbuild/commands/setup/setup_test.go
+++ b/cmd/cbuild/commands/setup/setup_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Arm Limited. All rights reserved.
+ * Copyright (c) 2024-2025 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/cmd/cbuild/commands/setup/setup_test.go
+++ b/cmd/cbuild/commands/setup/setup_test.go
@@ -21,6 +21,37 @@ func TestSetupCommand(t *testing.T) {
 	assert := assert.New(t)
 	csolutionFile := filepath.Join(testRoot, testDir, "TestSolution/test.csolution.yml")
 
+	t.Run("test valid command with -a", func(t *testing.T) {
+		cmd := commands.NewRootCmd()
+		cmd.SetArgs([]string{"setup", csolutionFile, "--active", "test"})
+
+		err := cmd.Execute()
+
+		// Though the command is valid, It fails for other reasons
+		assert.Error(err)
+		assert.Contains(err.Error(), "couldn't locate '../etc' directory relative to")
+	})
+
+	t.Run("test invalid arguments to -a option", func(t *testing.T) {
+		cmd := commands.NewRootCmd()
+		args := []string{"setup", csolutionFile, "-a", "-d"}
+		cmd.SetArgs(args)
+
+		err := cmd.Execute()
+		assert.Error(err)
+		assert.EqualError(err, "invalid input argument for '-a'")
+	})
+
+	t.Run("test invalid command with -a and -S", func(t *testing.T) {
+		cmd := commands.NewRootCmd()
+		args := []string{"setup", csolutionFile, "-a", "test", "-S"}
+		cmd.SetArgs(args)
+
+		err := cmd.Execute()
+		assert.Error(err)
+		assert.EqualError(err, "invalid command line arguments. Options '-a' and '-S' are mutually exclusive")
+	})
+
 	t.Run("test valid command", func(t *testing.T) {
 		cmd := commands.NewRootCmd()
 		cmd.SetArgs([]string{"setup", csolutionFile})
@@ -62,4 +93,5 @@ func TestSetupCommand(t *testing.T) {
 		err := cmd.Execute()
 		assert.Nil(err)
 	})
+
 }

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2025 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -72,6 +72,9 @@ func (b CSolutionBuilder) formulateArgs(command []string) (args []string) {
 	if b.Options.Quiet {
 		args = append(args, "--quiet")
 	}
+	if b.Options.TargetSet != "" {
+		args = append(args, "--active="+b.Options.TargetSet)
+	}
 	return
 }
 

--- a/pkg/builder/csolution/builder_test.go
+++ b/pkg/builder/csolution/builder_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2025 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/pkg/builder/csolution/builder_test.go
+++ b/pkg/builder/csolution/builder_test.go
@@ -471,6 +471,15 @@ func TestFormulateArg(t *testing.T) {
 		strArg := utils.NormalizePath(strings.Join(args, " "))
 		assert.Equal("convert --solution=../../../test/"+testDir+"/Test.csolution.yml --no-check-schema --no-update-rte --context=test.Debug+Target --context=test.Release+Target --context-set", strArg)
 	})
+
+	t.Run("test --active arg", func(t *testing.T) {
+		b.Options = builder.Options{
+			TargetSet: "test",
+		}
+		args := b.formulateArgs([]string{"convert"})
+		strArg := utils.NormalizePath(strings.Join(args, " "))
+		assert.Equal("convert --solution=../../../test/"+testDir+"/Test.csolution.yml --no-check-schema --no-update-rte --active=test", strArg)
+	})
 }
 
 func TestGetCbuildSetFilePath(t *testing.T) {

--- a/pkg/builder/interface.go
+++ b/pkg/builder/interface.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2025 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/pkg/builder/interface.go
+++ b/pkg/builder/interface.go
@@ -36,6 +36,7 @@ type Options struct {
 	Load            string
 	Output          string
 	Toolchain       string
+	TargetSet       string
 	Jobs            int
 	Quiet           bool
 	Debug           bool

--- a/pkg/errutils/errutils.go
+++ b/pkg/errutils/errutils.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Arm Limited. All rights reserved.
+ * Copyright (c) 2024-2025 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/pkg/errutils/errutils.go
+++ b/pkg/errutils/errutils.go
@@ -28,13 +28,16 @@ const (
 	ErrRequireArg             = "command requires an input file argument. Run '%s' for more information about a command"
 	ErrInvalidVersionString   = "invalid version %s. Expected %s"
 	ErrInvalidNumJobs         = "invalid number of job slots specified for parallel execution. Expected: j>0"
-	ErrMissingRequiredArg     = "setup command is missing mandatory option '--context-set'"
+	ErrMissingRequiredArg     = "setup command is missing mandatory option '--context-set' or '--active'"
 	ErrDeleteFailed           = "failed to delete: '%s'"
 	ErrPathNotExist           = "path does not exist: '%s'"
 	ErrFetchingAbsPath        = "unable to get absolute path: '%s'"
 	ErrInvalidPath            = "invalid path: '%s'"
 	ErrPerfResults            = "unable to save performance results: %s"
 	ErrNoCompilerRegistered   = "required compiler(s) not registered: '%s'"
+	ErrInvalidTargetSetUsage  = "invalid target-set usage. The '-a' option cannot be used with the '-c' or '-S'"
+	ErrInvalidSetUpArgs       = "invalid command line arguments. Options '-a' and '-S' are mutually exclusive"
+	ErrInvalidInputArg        = "invalid input argument for '%s'"
 )
 
 const (


### PR DESCRIPTION
## Fixes
- A part of https://github.com/Open-CMSIS-Pack/devtools/issues/2056

## Change
- Added `-a, --active` argument to `cbuild root` and `setup` command, which is propagated to csolution
```
Options:
  -a, --active arg         Select active target-set: <target-type>[@<set>]

```

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
