### PR TITLE
Clean only relevant contexts when using --active

### DIFF
--- a/test/data/TestSolution/test.csolution.yml
+++ b/test/data/TestSolution/test.csolution.yml
@@ -1,13 +1,17 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.3.0/tools/projmgr/schemas/csolution.schema.json
-
 solution:
   target-types:
     - type: CM3
       device: ARMCM3
+      target-set:
+        - set: #unnamed default
+        - set: Custom1
+        - set: Custom2
       misc:
         - compiler: GCC
     - type: CM0
       device: ARMCM0
+      target-set:
+        - set: Custom3
       misc:
         - compiler: GCC
 


### PR DESCRIPTION
## Fixes
- Only the selected contexts from the target set need to be cleaned when using the `-a` or `--active` option with `rebuild`.


## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
