### PR TITLE
[cbuild] Handle cmd line option `--active ""` (empty argument)

### DIFF
--- a/cmd/cbuild/commands/root.go
+++ b/cmd/cbuild/commands/root.go
@@ -142,12 +142,13 @@ func NewRootCmd() *cobra.Command {
 			frozenPacks, _ := cmd.Flags().GetBool("frozen-packs")
 			useCbuildgen, _ := cmd.Flags().GetBool("cbuildgen")
 			targetSet, _ := cmd.Flags().GetString("active")
+			useTargetSet := cmd.Flags().Changed("active")
 
 			// set cbuild2cmake as default tool
 			useCbuild2CMake := !useCbuildgen
 
 			// -a option is not compatible with -c or -S
-			if targetSet != "" && (len(contexts) > 0 || useContextSet) {
+			if useTargetSet && (len(contexts) > 0 || useContextSet) {
 				err := errutils.New(errutils.ErrInvalidTargetSetUsage)
 				log.Error(err)
 				return err
@@ -183,6 +184,7 @@ func NewRootCmd() *cobra.Command {
 				FrozenPacks:     frozenPacks,
 				UseCbuild2CMake: useCbuild2CMake,
 				TargetSet:       targetSet,
+				UseTargetSet:    useTargetSet,
 			}
 
 			configs, err := utils.GetInstallConfigs()

--- a/cmd/cbuild/commands/setup/setup.go
+++ b/cmd/cbuild/commands/setup/setup.go
@@ -72,18 +72,19 @@ func setUpProject(cmd *cobra.Command, args []string) error {
 	useCbuildgen, _ := cmd.Flags().GetBool("cbuildgen")
 	noDatabase, _ := cmd.Flags().GetBool("no-database")
 	targetSet, _ := cmd.Flags().GetString("active")
+	useTargetSet := cmd.Flags().Changed("active")
 
 	useCbuild2CMake := !useCbuildgen
 
 	// Option '-a' and '-S' are mutually exclusive
-	if len(targetSet) > 0 && useContextSet {
+	if useTargetSet && useContextSet {
 		err = errutils.New(errutils.ErrInvalidSetUpArgs)
 		log.Error(err)
 		return err
 	}
 
 	// Either '-a' or '-S' must be used
-	if len(targetSet) == 0 && !useContextSet {
+	if !useTargetSet && !useContextSet {
 		err = errutils.New(errutils.ErrMissingRequiredArg)
 		log.Error(err)
 		return err
@@ -117,6 +118,7 @@ func setUpProject(cmd *cobra.Command, args []string) error {
 		UseCbuild2CMake: useCbuild2CMake,
 		NoDatabase:      noDatabase,
 		TargetSet:       targetSet,
+		UseTargetSet:    useTargetSet,
 	}
 
 	configs, err := utils.GetInstallConfigs()

--- a/cmd/cbuild/commands/setup/setup_test.go
+++ b/cmd/cbuild/commands/setup/setup_test.go
@@ -32,6 +32,17 @@ func TestSetupCommand(t *testing.T) {
 		assert.Contains(err.Error(), "couldn't locate '../etc' directory relative to")
 	})
 
+	t.Run("test valid command with -a <empty arg>", func(t *testing.T) {
+		cmd := commands.NewRootCmd()
+		cmd.SetArgs([]string{"setup", csolutionFile, "--active", ""})
+
+		err := cmd.Execute()
+
+		// Though the command is valid, It fails for other reasons
+		assert.Error(err)
+		assert.Contains(err.Error(), "couldn't locate '../etc' directory relative to")
+	})
+
 	t.Run("test invalid arguments to -a option", func(t *testing.T) {
 		cmd := commands.NewRootCmd()
 		args := []string{"setup", csolutionFile, "-a", "-d"}

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -72,7 +72,7 @@ func (b CSolutionBuilder) formulateArgs(command []string) (args []string) {
 	if b.Options.Quiet {
 		args = append(args, "--quiet")
 	}
-	if b.Options.TargetSet != "" {
+	if b.Options.UseTargetSet {
 		args = append(args, "--active="+b.Options.TargetSet)
 	}
 	return

--- a/pkg/builder/csolution/builder_test.go
+++ b/pkg/builder/csolution/builder_test.go
@@ -474,11 +474,22 @@ func TestFormulateArg(t *testing.T) {
 
 	t.Run("test --active arg", func(t *testing.T) {
 		b.Options = builder.Options{
-			TargetSet: "test",
+			TargetSet:    "test",
+			UseTargetSet: true,
 		}
 		args := b.formulateArgs([]string{"convert"})
 		strArg := utils.NormalizePath(strings.Join(args, " "))
 		assert.Equal("convert --solution=../../../test/"+testDir+"/Test.csolution.yml --no-check-schema --no-update-rte --active=test", strArg)
+	})
+
+	t.Run("test --active <empty arg>", func(t *testing.T) {
+		b.Options = builder.Options{
+			TargetSet:    "",
+			UseTargetSet: true,
+		}
+		args := b.formulateArgs([]string{"convert"})
+		strArg := utils.NormalizePath(strings.Join(args, " "))
+		assert.Equal("convert --solution=../../../test/"+testDir+"/Test.csolution.yml --no-check-schema --no-update-rte --active=", strArg)
 	})
 }
 

--- a/pkg/builder/interface.go
+++ b/pkg/builder/interface.go
@@ -49,6 +49,7 @@ type Options struct {
 	Rebuild         bool
 	UpdateRte       bool
 	UseContextSet   bool
+	UseTargetSet    bool
 	FrozenPacks     bool
 	UseCbuild2CMake bool
 	NoDatabase      bool


### PR DESCRIPTION
## Changes
<!-- List the changes this PR introduces -->
Accept command line option `--active` with empty argument, forwarding it to `csolution`.
Being `--active` a "string option" rather than a "boolean flag", to be correctly parsed the "empty argument" needs to be in one of the formats:
```shell
--active=
--active ""
-a ""
```

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
