### PR TITLE
Retain *.cbuild-run.yml file on clean

### DIFF
--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -770,7 +770,7 @@ func (b CSolutionBuilder) Clean() (err error) {
 	}
 
 	// Clean tmp dir
-	if err := utils.DeleteAll(tmpDir, ""); err != nil {
+	if err := utils.DeleteAll(tmpDir, []string{}); err != nil {
 		if !b.Options.Clean {
 			log.Warn(err.Error())
 		}
@@ -793,7 +793,7 @@ func (b CSolutionBuilder) Clean() (err error) {
 			if err != nil {
 				log.Error("error cleaning '" + context + "'")
 			}
-			if err = utils.DeleteAll(outDir, "*.cbuild.yml"); err != nil {
+			if err = utils.DeleteAll(outDir, []string{"*.cbuild.yml", "*.cbuild-run.yml"}); err != nil {
 				if !b.Options.Clean {
 					log.Warn(err.Error())
 				}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -484,7 +484,7 @@ func TestDeleteAll(t *testing.T) {
 		}
 
 		// Call the DeleteAll function
-		err := DeleteAll(delDir, "")
+		err := DeleteAll(delDir, []string{})
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -498,7 +498,7 @@ func TestDeleteAll(t *testing.T) {
 	t.Run("Delete NonExistent Directory", func(t *testing.T) {
 		// Test deleting a non-existent directory
 		nonExistentDir := filepath.Join(testDir, "non_existent_dir")
-		err := DeleteAll(nonExistentDir, "")
+		err := DeleteAll(nonExistentDir, []string{})
 
 		// Verify no error
 		assert.Error(t, err)
@@ -515,7 +515,7 @@ func TestDeleteAll(t *testing.T) {
 		}
 
 		// Call the DeleteAll function
-		err := DeleteAll(emptyDir, "")
+		err := DeleteAll(emptyDir, []string{})
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -537,7 +537,7 @@ func TestDeleteAll(t *testing.T) {
 		}
 
 		// Call the DeleteAll function
-		err := DeleteAll(testFile, "")
+		err := DeleteAll(testFile, []string{})
 		assert.NoError(t, err)
 
 		// Clean up
@@ -552,7 +552,7 @@ func TestDeleteAll(t *testing.T) {
 		filePath = filepath.Join(delDir, "delete.txt")
 		_ = os.WriteFile(filePath, []byte("test content 2"), 0600)
 
-		err := DeleteAll(delDir, "*.log")
+		err := DeleteAll(delDir, []string{"*.log"})
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -566,7 +566,7 @@ func TestDeleteAll(t *testing.T) {
 	})
 
 	t.Run("non-existent root path", func(t *testing.T) {
-		err := DeleteAll("/non/existent/path", "")
+		err := DeleteAll("/non/existent/path", []string{})
 		if err == nil {
 			t.Error("expected error for non-existent path, got nil")
 		}
@@ -580,7 +580,7 @@ func TestDeleteAll(t *testing.T) {
 		filePath = filepath.Join(delDir, "delete.txt")
 		_ = os.WriteFile(filePath, []byte("test content 2"), 0600)
 
-		err := DeleteAll(delDir, "nonmatch/**")
+		err := DeleteAll(delDir, []string{"nonmatch/**"})
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -605,7 +605,7 @@ func TestDeleteAll(t *testing.T) {
 		filePath := filepath.Join(dataDir, "file.info")
 		_ = os.WriteFile(filePath, []byte("data"), 0600)
 
-		err := DeleteAll(delDir, "*.debug")
+		err := DeleteAll(delDir, []string{"*.debug", "*.info"})
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -616,8 +616,8 @@ func TestDeleteAll(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(delDir, "logs/log1.txt")); !os.IsNotExist(err) {
 			t.Error("excluded nested file was not deleted")
 		}
-		if _, err := os.Stat(filepath.Join(delDir, "data/file.info")); !os.IsNotExist(err) {
-			t.Error("non-excluded file was not deleted")
+		if _, err := os.Stat(filepath.Join(delDir, "data/file.info")); os.IsNotExist(err) {
+			t.Error("excluded nested file was deleted")
 		}
 	})
 }


### PR DESCRIPTION
- [filepath.Match](https://pkg.go.dev/path/filepath#Match) function doesn’t support multiple or complex patterns, so a new wrapper function was introduced to handle them.
 
## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
