### PR TITLE
[west support] Remove `constructed-files` workaround

### DIFF
--- a/pkg/utils/west.go
+++ b/pkg/utils/west.go
@@ -148,15 +148,13 @@ func AddWestFilesToCbuild(westInfo WestBuildInfo) error {
 	}
 
 	// Get all files and separate them by modules
-	var allFiles []string
-	fileTree := []Filetree{} // make(map[string][]string)
+	fileTree := []Filetree{}
 	for _, compileCommands := range compileCommandsData {
 		var file string
 		file, err = filepath.Rel(filepath.Dir(westInfo.Cbuild), compileCommands.File)
 		if err != nil {
 			file = compileCommands.File
 		}
-		allFiles = append(allFiles, filepath.ToSlash(file))
 		module := GetModule(filepath.ToSlash(compileCommands.File), modules)
 		AppendFileToGroup(&fileTree, module, filepath.ToSlash(file))
 	}
@@ -195,20 +193,6 @@ func AddWestFilesToCbuild(westInfo WestBuildInfo) error {
 
 	// Replace 'groups' node if it exists, otherwise append it
 	SetYamlNodeByKey(buildNode, groupsNode, "groups")
-
-	// Create constructed-files as a workaround for populating the outline view
-	constructedFilesNode := &yaml.Node{Kind: yaml.SequenceNode}
-	for _, file := range allFiles {
-		fileNode := &yaml.Node{Kind: yaml.MappingNode}
-		fileNode.Content = []*yaml.Node{
-			{Kind: yaml.ScalarNode, Value: "file"},
-			{Kind: yaml.ScalarNode, Value: file},
-		}
-		constructedFilesNode.Content = append(constructedFilesNode.Content, fileNode)
-	}
-
-	// Replace 'constructed-files' node if it exists, otherwise append it
-	SetYamlNodeByKey(buildNode, constructedFilesNode, "constructed-files")
 
 	// Update Cbuild file
 	var buf strings.Builder

--- a/pkg/utils/west_test.go
+++ b/pkg/utils/west_test.go
@@ -115,10 +115,6 @@ func TestWestUtils(t *testing.T) {
     - group: sub-module
       files:
         - file: /src/module/sub-module/sub-lib.c
-  constructed-files:
-    - file: /src/user/main.c
-    - file: /src/module/lib.c
-    - file: /src/module/sub-module/sub-lib.c
 `
 		assert.Equal(expected, string(cbuildContent))
 


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
-

## Changes
<!-- List the changes this PR introduces -->
-

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
