### PR TITLE
Removed redundant write permission from check-licenses job

### DIFF
--- a/.github/workflows/tpip-check.yml
+++ b/.github/workflows/tpip-check.yml
@@ -19,19 +19,19 @@ permissions:
 
 jobs:
   check-licenses:
-    # Avoid running this on forks
+    name: Check Third-Party Licenses
     if: github.repository == 'Open-CMSIS-Pack/cbuild'
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      checks: write
+
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
@@ -39,15 +39,18 @@ jobs:
           go-version-file: go.mod
           check-latest: true
 
-      - name: Go tidy
-        run:  go mod tidy
+      - name: Run go mod tidy
+        run: go mod tidy
 
       - name: Install go-licenses
-        run:  go install github.com/google/go-licenses@latest
+        run: go install github.com/google/go-licenses@latest
 
-      - name: Generate TPIP Report
-        run:  |
-          go-licenses report . --ignore github.com/Open-CMSIS-Pack/cbuild --template ../../scripts/template/${{ env.tpip_report }}.template > ../../${{ env.tpip_report }}
+      - name: Generate TPIP report
+        run: |
+          go-licenses report . \
+            --ignore github.com/Open-CMSIS-Pack/cbuild \
+            --template ../../scripts/template/${{ env.tpip_report }}.template \
+            > ../../${{ env.tpip_report }}
         working-directory: ./cmd/cbuild
 
       - name: Archive TPIP report
@@ -56,29 +59,34 @@ jobs:
           name: tpip-report
           path: ./${{ env.tpip_report }}
 
-      - name: Print TPIP Report
+      - name: Print TPIP report to summary
         run: cat ${{ env.tpip_report }} >> $GITHUB_STEP_SUMMARY
 
-      - name: Check Licenses
-        run: go-licenses check . --ignore github.com/Open-CMSIS-Pack/cbuild --disallowed_types=forbidden,restricted
+      - name: Validate licenses
+        run: |
+          go-licenses check . \
+            --ignore github.com/Open-CMSIS-Pack/cbuild \
+            --disallowed_types=forbidden,restricted
         working-directory: ./cmd/cbuild
 
   commit-changes:
-    permissions:
-      # Minimal permissions with PAT
-      contents: read
-      pull-requests: read
+    name: Create TPIP Update PR
     if: (github.event_name == 'schedule') || (github.event_name == 'workflow_dispatch')
-    needs: [ check-licenses ]
+    needs: [check-licenses]
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -88,10 +96,10 @@ jobs:
         with:
           name: tpip-report
 
-      - name: Create Pull Request
+      - name: Create pull request
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
         with:
-          token: ${{ secrets.GRASCI_WORKFLOW_UPDATE  }}
+          token: ${{ secrets.GRASCI_WORKFLOW_UPDATE }}
           commit-message: Update TPIP report
           title: ':robot: [TPIP] Automated report updates'
           body: |
@@ -102,4 +110,4 @@ jobs:
           delete-branch: true
           labels: TPIP
           reviewers: soumeh01
-          draft: true  # Create as draft PR for manual review
+          draft: true


### PR DESCRIPTION
## Fix:
- Addressing : https://github.com/Open-CMSIS-Pack/cbuild/security/code-scanning/165
## Changes
- Fixed: Workflow security issue as write permission is not needed
- Cleanup of the workflow

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
