### PR TITLE
Fix: Failure when selecting --rebuild and the target set specifies and image

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -352,9 +352,11 @@ func ResolveContexts(allContext []string, contextFilters []string) ([]string, er
 			if err != nil {
 				return nil, err
 			}
-			if match && !Contains(selectedContexts, context) {
-				matchFound = match
-				selectedContexts = append(selectedContexts, context)
+			if match {
+				if !Contains(selectedContexts, context) {
+					selectedContexts = append(selectedContexts, context)
+				}
+				matchFound = true
 			}
 		}
 		if !matchFound {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -7,6 +7,7 @@
 package utils
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -287,6 +288,7 @@ func TestResolveContexts(t *testing.T) {
 		{[]string{"Project2.Rel*+Tar*"}, []string{"Project2.Release+Target", "Project2.Release+Target2"}, false},
 		{[]string{".Rel*+*2"}, []string{"Project1.Release+Target2", "Project2.Release+Target2"}, false},
 		{[]string{"Project*.Release+*"}, []string{"Project1.Release+Target", "Project1.Release+Target2", "Project2.Release+Target", "Project2.Release+Target2"}, false},
+		{[]string{"+Target", "Project1.Debug+Target"}, []string{"Project1.Debug+Target", "Project1.Release+Target", "Project2.Debug+Target", "Project2.Release+Target", "Project4+Target"}, false},
 
 		// negative tests
 		{[]string{"Unknown"}, nil, true},
@@ -304,14 +306,17 @@ func TestResolveContexts(t *testing.T) {
 		{[]string{"Project1.Debug+Target+Target2"}, nil, true},
 	}
 
-	for _, test := range testCases {
+	for idx, test := range testCases {
 		outResolvedContexts, err := ResolveContexts(allContexts, test.contextFilters)
-		if test.ExpectError {
-			assert.Error(err)
-		} else {
-			assert.Nil(err)
+		caseInfo := func() string {
+			return fmt.Sprintf("TestCase #%d: contextFilters=%v", idx, test.contextFilters)
 		}
-		assert.Equal(test.expectedResolvedContexts, outResolvedContexts)
+		if test.ExpectError {
+			assert.Error(err, caseInfo())
+		} else {
+			assert.Nil(err, caseInfo())
+		}
+		assert.Equal(test.expectedResolvedContexts, outResolvedContexts, caseInfo())
 	}
 }
 


### PR DESCRIPTION
## Fixes
- [[cbuild] fails when selecting --rebuild and the target set specifies and image](https://github.com/Open-CMSIS-Pack/cbuild/issues/537)

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
