### PR TITLE
Improve `--skip-convert` handling

### DIFF
--- a/pkg/builder/csolution/builder_test.go
+++ b/pkg/builder/csolution/builder_test.go
@@ -289,6 +289,12 @@ func TestBuild(t *testing.T) {
 		err := b.Build()
 		assert.Error(err)
 	})
+
+	t.Run("test build csolution with skip convert flag", func(t *testing.T) {
+		b.Options.SkipConvert = true
+		err := b.Build()
+		assert.Error(err)
+	})
 }
 
 func TestRebuild(t *testing.T) {


### PR DESCRIPTION
## Changes
<!-- List the changes this PR introduces -->
- Check the existence of `cbuild-idx.yml` and `cbuild.yml files when using `--skip-convert` flag to avoid failing.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
