### PR TITLE
Fixed linter warning

### DIFF
--- a/pkg/utils/exec.go
+++ b/pkg/utils/exec.go
@@ -55,6 +55,7 @@ func (r Runner) ExecuteCommand(program string, quiet bool, args ...string) (stri
 		ptmx, ptyErr := pty.New()
 		if ptyErr == nil {
 			defer ptmx.Close()
+			// #nosec G115 os.Stdout.Fd() is safe here for terminal size
 			w, h, ptyErr := term.GetSize(int(os.Stdout.Fd()))
 			if ptyErr == nil && w > 0 && h > 0 {
 				_ = ptmx.Resize(w, h)

--- a/pkg/utils/west.go
+++ b/pkg/utils/west.go
@@ -261,6 +261,7 @@ func CheckEnvVars(vars []string) {
 		value := os.Getenv(key)
 		if value == "" {
 			log.Warn("missing " + key + " environment variable")
+			// #nosec G703 value comes from environment variable (deployment config)
 		} else if _, err := os.Stat(value); os.IsNotExist(err) {
 			log.Warn(key + " environment variable specifies non-existent directory: " + value)
 		}


### PR DESCRIPTION
## Issue
```
  Error: /home/runner/work/cbuild/cbuild/pkg/utils/exec.go:58:36: G115: integer overflow conversion uintptr -> int (gosec)
  			w, h, ptyErr := term.GetSize(int(os.Stdout.Fd()))
  			                                ^
  Error: /home/runner/work/cbuild/cbuild/pkg/utils/west.go:264:30: G703: Path traversal via taint analysis (gosec)
  		} else if _, err := os.Stat(value); os.IsNotExist(err) {
```

## Changes
- Suppressing the warning as the recent linter specifications are too strict and not relevant in our case

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
