### PR TITLE
Improve `tmp` directory clean

### DIFF
--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -808,8 +808,8 @@ func (b CSolutionBuilder) Clean() (err error) {
 		}
 	}
 
-	// Clean tmp dir
-	if err := utils.DeleteAll(tmpDir, []string{}); err != nil {
+	// Clean tmp dir, avoid to delete *.cbuild.yml and *.cbuild-run.yml files
+	if err := utils.DeleteAll(tmpDir, []string{"*.cbuild.yml", "*.cbuild-run.yml"}); err != nil {
 		if !b.Options.Clean {
 			log.Warn(err.Error())
 		}

--- a/pkg/builder/csolution/builder_test.go
+++ b/pkg/builder/csolution/builder_test.go
@@ -814,3 +814,36 @@ func TestIsCompilerRootChanged(t *testing.T) {
 	})
 
 }
+
+func TestCleanTmpOut(t *testing.T) {
+	assert := assert.New(t)
+	b := CSolutionBuilder{
+		BuilderParams: builder.BuilderParams{
+			Runner:    RunnerMock{},
+			InputFile: filepath.Join(testRoot, testDir, "TestSolution/test.csolution.yml"),
+			InstallConfigs: utils.Configurations{
+				BinPath: configs.BinPath,
+				BinExtn: configs.BinExtn,
+				EtcPath: configs.EtcPath,
+			},
+		},
+	}
+	t.Run("test clean when 'out' directory is inside 'tmp' directory", func(t *testing.T) {
+		b.Options.UseCbuild2CMake = true
+		b.Options.Contexts = []string{"test.Debug+CM0"}
+		tmpDir := filepath.Join(testRoot, testDir, "TestSolution/tmpdir")
+		outDir := filepath.Join(tmpDir, "test")
+		_ = os.MkdirAll(outDir, os.ModePerm)
+		cbuildFile := filepath.Join(outDir, "test.Debug+CM0.cbuild.yml")
+		_ = os.WriteFile(cbuildFile, []byte("dummy"), 0600)
+		spuriousFile := filepath.Join(tmpDir, "spurious.txt")
+		_ = os.WriteFile(spuriousFile, []byte("dummy"), 0600)
+
+		err := b.Clean()
+		assert.Nil(err)
+		assert.FileExists(cbuildFile)
+		assert.NoFileExists(spuriousFile)
+
+		_ = os.RemoveAll(tmpDir)
+	})
+}

--- a/test/data/TestSolution/test.csolution.yml
+++ b/test/data/TestSolution/test.csolution.yml
@@ -51,3 +51,4 @@ solution:
 
   output-dirs:
     tmpdir: ./tmpdir
+    outdir: ./tmpdir/$Project$


### PR DESCRIPTION
## Changes
<!-- List the changes this PR introduces -->
- Avoid to delete *.cbuild.yml and *.cbuild-run.yml files when cleaning the `tmp` directory, similarly when cleaning the `out` directory. This is particularly important when the `out` directory is placed inside `tmp` directory via `output-dirs` customization, for example:
```
solution:
  output-dirs:
    tmpdir: build
    outdir: $SolutionDir()$/build/$Project$.$BuildType$
```
- Add test case

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
