### PR TITLE
Remove `--quiet` for `csolution convert` command

### DIFF
--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -153,11 +153,6 @@ func (b CSolutionBuilder) generateBuildFiles() (err error) {
 		args = append(args, "--context="+allYmlOrderedContexts[0])
 	}
 
-	// on setup command, run csolution convert command with --quiet
-	if b.Setup {
-		args = append(args, "--quiet")
-	}
-
 	if !b.Options.UseCbuild2CMake {
 		args = append(args, "--cbuildgen")
 	}


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- https://github.com/Open-CMSIS-Pack/devtools/issues/1767

## Changes
<!-- List the changes this PR introduces -->
- Remove `--quiet` for `csolution convert` command from default. Observed behavior based on local test.
  The test project contains two warnings and one error message.
  - Before changes
    ```
    PS C:\Projects\TESTPROJECT> cbuild setup .\test.csolution.yml --context-set
    error csolution: conflict: component 'RteTest:CORE' is listed multiple times
    error csolution: processing context 'test1.Debug+CM0' failed
    ```
  - After changes
    ```
    PS C:\Projects\TESTPROJECT> cbuild setup .\test.csolution.yml --context-set
    C:/Projects/TESTPROJECT/test.csolution.yml - warning csolution: cproject.yml files should be placed in separate sub-directories
    warning csolution: 'tmpdir' does not support access sequences and must be relative to csolution.yml
    error csolution: conflict: component 'Startup' is listed multiple times
    error csolution: processing context 'test1.Debug+CM0' failed
    ```

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
