### PR TITLE
Get `tmpdir` default base directory when access sequences are used

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -467,7 +467,8 @@ func GetTmpDir(csolutionFile string, outputDir string) (string, error) {
 	}
 
 	tmpDir := data.Solution.OutputDirs.Tmpdir
-	if tmpDir == "" {
+	accessSequencesRegex := regexp.MustCompile(`\$.*?\$`)
+	if tmpDir == "" || accessSequencesRegex.MatchString(tmpDir) {
 		tmpDir = defaultTmpDir
 	}
 


### PR DESCRIPTION
## Changes
<!-- List the changes this PR introduces -->
- Related to https://github.com/Open-CMSIS-Pack/devtools/pull/2415

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
