### PR TITLE
Control output handling for list commands

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+
 jobs:
   analyze:
     name: Analyze
@@ -30,8 +35,6 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    strategy:
-      fail-fast: false
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,6 +6,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   dependency-review:
     if: github.repository_owner == 'Open-CMSIS-Pack'

--- a/.github/workflows/global.yaml
+++ b/.github/workflows/global.yaml
@@ -12,6 +12,9 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   copyright:
     runs-on: ubuntu-latest

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -10,6 +10,9 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   markdown-check:
     uses: Open-CMSIS-Pack/workflows-and-actions-collection/.github/workflows/markdown-lint.yml@v1.0.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-and-verify:
     permissions:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,6 +14,9 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   analysis:
     # Avoid running this on forks

--- a/.github/workflows/tpip-check.yml
+++ b/.github/workflows/tpip-check.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   tpip_report: "third_party_licenses.md"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,23 @@
 # Binaries for programs and plugins
-*.exe
-*.exe~
-*.dll
-*.so
-*.dylib
+**/*.bat
+**/*.exe
+**/*.exe~
+**/*.dll
+**/*.so
+**/*.dylib
 
 # Test binary, built with `go test -c`
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+**/.clangd
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Folders
+**/etc/*
+.vscode
+test/*/
+!test/data/

--- a/cmd/cbuild/commands/list/list_contexts.go
+++ b/cmd/cbuild/commands/list/list_contexts.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2026 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -52,7 +52,9 @@ func listContexts(cmd *cobra.Command, args []string) error {
 	filter, _ := cmd.Flags().GetString("filter")
 	p := csolution.CSolutionBuilder{
 		BuilderParams: builder.BuilderParams{
-			Runner: utils.Runner{},
+			Runner: utils.Runner{
+				IsListCmd: true,
+			},
 			Options: builder.Options{
 				SchemaChk: !noSchemaChk,
 				Filter:    filter,

--- a/cmd/cbuild/commands/list/list_environment.go
+++ b/cmd/cbuild/commands/list/list_environment.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2026 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -26,7 +26,9 @@ func listEnvironment(cmd *cobra.Command, args []string) error {
 
 	p := csolution.CSolutionBuilder{
 		BuilderParams: builder.BuilderParams{
-			Runner:         utils.Runner{},
+			Runner: utils.Runner{
+				IsListCmd: true,
+			},
 			InstallConfigs: configs,
 		},
 	}

--- a/cmd/cbuild/commands/list/list_target_sets.go
+++ b/cmd/cbuild/commands/list/list_target_sets.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Arm Limited. All rights reserved.
+ * Copyright (c) 2025-2026 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -55,7 +55,9 @@ func listTargetSets(cmd *cobra.Command, args []string) error {
 
 	p := csolution.CSolutionBuilder{
 		BuilderParams: builder.BuilderParams{
-			Runner: utils.Runner{},
+			Runner: utils.Runner{
+				IsListCmd: true,
+			},
 			Options: builder.Options{
 				SchemaChk: !noSchemaChk,
 				Filter:    filter,

--- a/cmd/cbuild/commands/list/list_toolchains.go
+++ b/cmd/cbuild/commands/list/list_toolchains.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2026 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -53,7 +53,9 @@ func listToolchains(cmd *cobra.Command, args []string) error {
 
 	p := csolution.CSolutionBuilder{
 		BuilderParams: builder.BuilderParams{
-			Runner: utils.Runner{},
+			Runner: utils.Runner{
+				IsListCmd: true,
+			},
 			Options: builder.Options{
 				Contexts:      contexts,
 				UseContextSet: useContextSet,

--- a/pkg/utils/exec.go
+++ b/pkg/utils/exec.go
@@ -26,8 +26,9 @@ type RunnerInterface interface {
 }
 
 type Runner struct {
-	outBytes []byte
-	quiet    bool
+	outBytes  []byte // Captures the output bytes from the executed command
+	quiet     bool   // If true, suppresses output to the standard logger
+	IsListCmd bool   // Indicates if the current command is a 'list' command
 }
 
 func (r *Runner) Write(bytes []byte) (n int, err error) {
@@ -50,7 +51,7 @@ func (r Runner) ExecuteCommand(program string, quiet bool, args ...string) (stri
 	}
 
 	var err error
-	if !quiet && isTerminal() {
+	if !r.IsListCmd && isTerminal() {
 		// Use pty to preserve colors and interactive output
 		ptmx, ptyErr := pty.New()
 		if ptyErr == nil {


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- https://github.com/Open-CMSIS-Pack/cbuild/issues/585

## Changes
<!-- List the changes this PR introduces -->
- Broaden `.gitignore` patterns for binaries, config folders, and files
- Add `IsListCmd` field to `utils.Runner` to control output handling for list commands
- Added env variable name FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 matches GitHub's official documentation for the Node 24 opt-in mechanism.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
