### PR TITLE
refactor: update debug flag description for clarity

### DIFF
--- a/cmd/cbuild/commands/build/buildcprj.go
+++ b/cmd/cbuild/commands/build/buildcprj.go
@@ -116,7 +116,7 @@ func init() {
 	BuildCPRJCmd.Flags().IntP("jobs", "j", 0, "Number of job slots for parallel execution")
 	BuildCPRJCmd.Flags().BoolP("help", "h", false, "Print usage")
 	BuildCPRJCmd.Flags().BoolP("quiet", "q", false, "Suppress output messages except build invocations")
-	BuildCPRJCmd.Flags().BoolP("debug", "d", false, "Enable debug messages")
+	BuildCPRJCmd.Flags().BoolP("debug", "d", false, "Enable debug messages of the cmsis build tools")
 	BuildCPRJCmd.Flags().BoolP("verbose", "v", false, "Enable verbose messages from toolchain builds")
 	BuildCPRJCmd.Flags().BoolP("clean", "C", false, "Remove intermediate and output directories")
 	BuildCPRJCmd.Flags().BoolP("packs", "p", false, "Download missing software packs with cpackget")

--- a/cmd/cbuild/commands/root.go
+++ b/cmd/cbuild/commands/root.go
@@ -248,7 +248,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.Flags().BoolP("version", "V", false, "Print version")
 	rootCmd.Flags().BoolP("help", "h", false, "Print usage")
 	rootCmd.Flags().BoolP("quiet", "q", false, "Suppress output messages except build invocations")
-	rootCmd.Flags().BoolP("debug", "d", false, "Enable debug messages")
+	rootCmd.Flags().BoolP("debug", "d", false, "Enable debug messages of the cmsis build tools")
 	rootCmd.Flags().BoolP("verbose", "v", false, "Enable verbose messages from toolchain builds")
 	rootCmd.Flags().BoolP("clean", "C", false, "Remove intermediate and output directories")
 	rootCmd.Flags().BoolP("packs", "p", false, "Download missing software packs with cpackget")

--- a/cmd/cbuild/commands/setup/setup.go
+++ b/cmd/cbuild/commands/setup/setup.go
@@ -201,7 +201,7 @@ func init() {
 	SetUpCmd.DisableFlagsInUseLine = true
 	SetUpCmd.Flags().BoolP("help", "h", false, "Print usage")
 	SetUpCmd.Flags().BoolP("quiet", "q", false, "Suppress output messages except build invocations")
-	SetUpCmd.Flags().BoolP("debug", "d", false, "Enable debug messages")
+	SetUpCmd.Flags().BoolP("debug", "d", false, "Enable debug messages of the cmsis build tools")
 	SetUpCmd.Flags().BoolP("verbose", "v", false, "Enable verbose messages from toolchain builds")
 	SetUpCmd.Flags().BoolP("clean", "C", false, "Remove intermediate and output directories")
 	SetUpCmd.Flags().BoolP("packs", "p", false, "Download missing software packs with cpackget")


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- https://github.com/Open-CMSIS-Pack/devtools/issues/2421

## Changes
<!-- List the changes this PR introduces -->
- This pull request updates the help text for the `--debug` (`-d`) flag in several command-line interfaces to clarify that it enables debug messages specifically for the CMSIS build tools.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
