### PR TITLE
Fix: Failure of internal commands with quite mode

### DIFF
--- a/pkg/utils/exec.go
+++ b/pkg/utils/exec.go
@@ -51,7 +51,7 @@ func (r Runner) ExecuteCommand(program string, quiet bool, args ...string) (stri
 	}
 
 	var err error
-	if !r.IsListCmd && isTerminal() {
+	if !quiet && !r.IsListCmd && isTerminal() {
 		// Use pty to preserve colors and interactive output
 		ptmx, ptyErr := pty.New()
 		if ptyErr == nil {


### PR DESCRIPTION
## Fixes
- #585 

## Changes
- The change fixes the regression introduced [here](https://github.com/Open-CMSIS-Pack/cbuild/pull/589/changes#diff-ce145a4bb4fe260559e08df65c268267e5b81e737b1fc4c46937dbf0930901adR54). That resulted in internal command extectued in `quite=true` failed and run in verbose mode.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
