### PR TITLE
No warning on try deleting non-existent folder

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -542,10 +542,11 @@ func matchAnyPattern(filename string, patterns []string) (bool, error) {
 
 // DeleteAll removes everything under path except files whose base name
 // matches any of the provided glob patterns. If patterns is empty, it just calls os.RemoveAll.
+// silently exits (nothing to delete) if the path does not exist.
 func DeleteAll(path string, excludeFilePatterns []string) error {
 	// check path exists
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return errutils.New(errutils.ErrPathNotExist, path)
+		return nil // nothing to delete
 	}
 
 	// if no patterns given, just delete everything

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -506,7 +506,7 @@ func TestDeleteAll(t *testing.T) {
 		err := DeleteAll(nonExistentDir, []string{})
 
 		// Verify no error
-		assert.Error(t, err)
+		assert.Nil(t, err)
 	})
 
 	t.Run("Delete Empty Directory", func(t *testing.T) {
@@ -572,8 +572,8 @@ func TestDeleteAll(t *testing.T) {
 
 	t.Run("non-existent root path", func(t *testing.T) {
 		err := DeleteAll("/non/existent/path", []string{})
-		if err == nil {
-			t.Error("expected error for non-existent path, got nil")
+		if err != nil {
+			t.Error("expected no error for non-existent path, got error")
 		}
 	})
 


### PR DESCRIPTION
## Changes
- If the target folder does not exist, exit silently since there is nothing to delete

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
