### PR TITLE
[cbuild] Add command orchestration for zephyr module generation

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -26,6 +26,15 @@ Follow the steps below to start developing for `cbuild`:
 7. Done! You can now start modifying the source code. Please refer to [contributing guide](CONTRIBUTING.md)
 for guidelines.
 
+# Debugging
+
+Workaround for VS Code debug issue concerning DWARFv5 https://github.com/go-delve/delve/issues/4268:
+Build `dlv` with go 1.25.0:
+
+```bash
+GOTOOLCHAIN="go1.25.0" go install -a github.com/go-delve/delve/cmd/dlv@latest
+```
+
 # Releasing
 
 If you have the right to push to the `main` branch of this repo, you might be entitled to

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -26,6 +26,13 @@ Follow the steps below to start developing for `cbuild`:
 7. Done! You can now start modifying the source code. Please refer to [contributing guide](CONTRIBUTING.md)
 for guidelines.
 
+# Debugging
+Workaround for VS Code debug issue concerning DWARFv5 https://github.com/go-delve/delve/issues/4268:
+Build `dlv` with go 1.25.0: 
+```
+GOTOOLCHAIN="go1.25.0" go install -a github.com/go-delve/delve/cmd/dlv@latest
+```
+
 # Releasing
 
 If you have the right to push to the `main` branch of this repo, you might be entitled to

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -27,9 +27,11 @@ Follow the steps below to start developing for `cbuild`:
 for guidelines.
 
 # Debugging
+
 Workaround for VS Code debug issue concerning DWARFv5 https://github.com/go-delve/delve/issues/4268:
-Build `dlv` with go 1.25.0: 
-```
+Build `dlv` with go 1.25.0:
+
+```bash
 GOTOOLCHAIN="go1.25.0" go install -a github.com/go-delve/delve/cmd/dlv@latest
 ```
 

--- a/cmd/cbuild/commands/root.go
+++ b/cmd/cbuild/commands/root.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025 Arm Limited. All rights reserved.
+ * Copyright (c) 2022-2026 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,6 +16,7 @@ import (
 	"github.com/Open-CMSIS-Pack/cbuild/v2/cmd/cbuild/commands/build"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/cmd/cbuild/commands/list"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/cmd/cbuild/commands/setup"
+	"github.com/Open-CMSIS-Pack/cbuild/v2/cmd/cbuild/commands/zephyr"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder/cproject"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder/csolution"
@@ -279,7 +280,7 @@ func NewRootCmd() *cobra.Command {
 	_ = rootCmd.Flags().MarkHidden("update")
 
 	rootCmd.SetFlagErrorFunc(FlagErrorFunc)
-	rootCmd.AddCommand(build.BuildCPRJCmd, list.ListCmd, setup.SetUpCmd)
+	rootCmd.AddCommand(build.BuildCPRJCmd, list.ListCmd, setup.SetUpCmd, zephyr.ZephyrCmd)
 	return rootCmd
 }
 

--- a/cmd/cbuild/commands/root.go
+++ b/cmd/cbuild/commands/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Open-CMSIS-Pack/cbuild/v2/cmd/cbuild/commands/build"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/cmd/cbuild/commands/list"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/cmd/cbuild/commands/setup"
+	"github.com/Open-CMSIS-Pack/cbuild/v2/cmd/cbuild/commands/zephyr"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder/cproject"
 	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder/csolution"
@@ -281,7 +282,7 @@ func NewRootCmd() *cobra.Command {
 	_ = rootCmd.Flags().MarkHidden("update")
 
 	rootCmd.SetFlagErrorFunc(FlagErrorFunc)
-	rootCmd.AddCommand(build.BuildCPRJCmd, list.ListCmd, setup.SetUpCmd)
+	rootCmd.AddCommand(build.BuildCPRJCmd, list.ListCmd, setup.SetUpCmd, zephyr.ZephyrCmd)
 	return rootCmd
 }
 

--- a/cmd/cbuild/commands/zephyr/zephyr.go
+++ b/cmd/cbuild/commands/zephyr/zephyr.go
@@ -84,6 +84,16 @@ func normalizeLayers(input []string) []string {
 	return layers
 }
 
+func isSimpleModuleName(moduleName string) bool {
+	if moduleName == "." || moduleName == ".." {
+		return false
+	}
+	if strings.ContainsAny(moduleName, `/\`) {
+		return false
+	}
+	return moduleName == filepath.Base(moduleName)
+}
+
 func resolveAndValidateLayers(input []string, cwd string) ([]string, error) {
 	layers := normalizeLayers(input)
 	resolvedLayers := make([]string, 0, len(layers))
@@ -159,6 +169,11 @@ func generateZephyrModule(cmd *cobra.Command, _ []string) error {
 	moduleName = strings.TrimSpace(moduleName)
 	if moduleName == "" {
 		err := errutils.New(errutils.ErrMissingModuleArg)
+		log.Error(err)
+		return err
+	}
+	if !isSimpleModuleName(moduleName) {
+		err := errutils.New(errutils.ErrInvalidInputArg, "--module")
 		log.Error(err)
 		return err
 	}
@@ -252,7 +267,7 @@ func generateZephyrModule(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	_, err = runner.ExecuteCommand(csolutionBin, false, solutionFile, "convert")
+	_, err = runner.ExecuteCommand(csolutionBin, false, "convert", solutionFile)
 	if err != nil {
 		log.Error(err)
 		return err
@@ -266,22 +281,29 @@ func generateZephyrModule(cmd *cobra.Command, _ []string) error {
 	}
 
 	sourceModuleDir := filepath.Join(tmpDir, moduleName)
-	if _, statErr := os.Stat(sourceModuleDir); statErr == nil {
-		destinationModuleDir := filepath.Join(originalDir, moduleName)
-		if _, existsErr := os.Stat(destinationModuleDir); existsErr == nil {
-			err = errutils.New(errutils.ErrOverwritingDestination, destinationModuleDir)
-			log.Warn(err)
+	if _, statErr := os.Stat(sourceModuleDir); statErr != nil {
+		if os.IsNotExist(statErr) {
+			err = errutils.New(errutils.ErrPathNotExist, sourceModuleDir)
+		} else {
+			err = statErr
 		}
+		log.Error(err)
+		return err
+	}
 
-		if err = os.RemoveAll(destinationModuleDir); err != nil {
-			log.Error(err)
-			return err
-		}
+	destinationModuleDir := filepath.Join(originalDir, moduleName)
+	if _, existsErr := os.Stat(destinationModuleDir); existsErr == nil {
+		log.Warn("overwriting existing destination:", destinationModuleDir)
+	}
 
-		if err = os.Rename(sourceModuleDir, destinationModuleDir); err != nil {
-			log.Error(err)
-			return err
-		}
+	if err = os.RemoveAll(destinationModuleDir); err != nil {
+		log.Error(err)
+		return err
+	}
+
+	if err = os.Rename(sourceModuleDir, destinationModuleDir); err != nil {
+		log.Error(err)
+		return err
 	}
 
 	return nil

--- a/cmd/cbuild/commands/zephyr/zephyr.go
+++ b/cmd/cbuild/commands/zephyr/zephyr.go
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2026 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package zephyr
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	builder "github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder"
+	csolution "github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder/csolution"
+	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/errutils"
+	log "github.com/Open-CMSIS-Pack/cbuild/v2/pkg/logger"
+	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultToolchain = "GCC"
+	defaultDevice    = "ARMCM55"
+	defaultPack      = "ARM::Cortex_DFP"
+)
+
+var (
+	getInstallConfigs = utils.GetInstallConfigs
+	runnerInterface   = func() utils.RunnerInterface { return utils.Runner{} }
+)
+
+func createSolutionContent(moduleName string, toolchain string, device string, packs []string) string {
+	var builder strings.Builder
+	builder.WriteString("solution:\n\n")
+	builder.WriteString("  compiler: ")
+	builder.WriteString(toolchain)
+	builder.WriteString("\n\n")
+	builder.WriteString("  packs:\n")
+	for _, pack := range packs {
+		builder.WriteString("    - pack: ")
+		builder.WriteString(pack)
+		builder.WriteString("\n")
+	}
+	builder.WriteString("\n")
+	builder.WriteString("  target-types:\n")
+	builder.WriteString("    - type: ")
+	builder.WriteString(device)
+	builder.WriteString("\n")
+	builder.WriteString("      device: ")
+	builder.WriteString(device)
+	builder.WriteString("\n\n")
+	builder.WriteString("  projects:\n")
+	builder.WriteString("    - project: ")
+	builder.WriteString(moduleName)
+	builder.WriteString(".cproject.yml\n")
+
+	return builder.String()
+}
+
+func createProjectContent(clayers []string) string {
+	var builder strings.Builder
+	builder.WriteString("project:\n\n")
+	builder.WriteString("  layers:\n")
+
+	for _, clayer := range clayers {
+		builder.WriteString("    - layer: ")
+		builder.WriteString(clayer)
+		builder.WriteString("\n")
+	}
+
+	return builder.String()
+}
+
+func normalizeLayers(input []string) []string {
+	layers := make([]string, 0, len(input))
+	for _, item := range input {
+		layer := strings.TrimSpace(item)
+		if layer == "" {
+			continue
+		}
+		layers = append(layers, layer)
+	}
+	return layers
+}
+
+func resolveAndValidateLayers(input []string, cwd string) ([]string, error) {
+	layers := normalizeLayers(input)
+	resolvedLayers := make([]string, 0, len(layers))
+
+	for _, layer := range layers {
+		layerPath := layer
+		if !filepath.IsAbs(layerPath) {
+			layerPath = filepath.Join(cwd, layerPath)
+		}
+
+		absolutePath, err := filepath.Abs(layerPath)
+		if err != nil {
+			return nil, errutils.New(errutils.ErrInvalidClayerPath, layer, err)
+		}
+
+		if !strings.HasSuffix(strings.ToLower(absolutePath), ".clayer.yml") {
+			return nil, errutils.New(errutils.ErrInvalidFileExtension, layer, "*.clayer.yml")
+		}
+
+		info, err := os.Stat(absolutePath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, errutils.New(errutils.ErrFileNotExist, absolutePath)
+			}
+			return nil, errutils.New(errutils.ErrClayerAccess, absolutePath, err)
+		}
+
+		if info.IsDir() {
+			return nil, errutils.New(errutils.ErrClayerPathIsDirectory, absolutePath)
+		}
+
+		resolvedLayers = append(resolvedLayers, absolutePath)
+	}
+
+	return resolvedLayers, nil
+}
+
+func makeLayersRelativeToProject(input []string, projectFile string) ([]string, error) {
+	projectDir := filepath.Dir(projectFile)
+	relativeLayers := make([]string, 0, len(input))
+
+	for _, layer := range input {
+		relativeLayer, err := filepath.Rel(projectDir, layer)
+		if err != nil {
+			return nil, errutils.New(errutils.ErrRelativizeClayerPath, layer, projectFile, err)
+		}
+		relativeLayers = append(relativeLayers, filepath.ToSlash(relativeLayer))
+	}
+
+	return relativeLayers, nil
+}
+
+func getToolBinary(binPath string, name string, ext string) (string, error) {
+	toolPath := filepath.Join(binPath, name+ext)
+	if _, err := os.Stat(toolPath); err != nil {
+		return "", err
+	}
+	return toolPath, nil
+}
+
+func generateZephyrModule(cmd *cobra.Command, _ []string) error {
+	moduleName, _ := cmd.Flags().GetString("module")
+	toolchain, _ := cmd.Flags().GetString("toolchain")
+	device, _ := cmd.Flags().GetString("device")
+	clayers, _ := cmd.Flags().GetStringSlice("clayer")
+	packs, _ := cmd.Flags().GetStringSlice("packs")
+	originalDir, err := os.Getwd()
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	moduleName = strings.TrimSpace(moduleName)
+	if moduleName == "" {
+		err := errutils.New(errutils.ErrMissingModuleArg)
+		log.Error(err)
+		return err
+	}
+
+	validLayers, err := resolveAndValidateLayers(clayers, originalDir)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	if len(validLayers) == 0 {
+		err := errutils.New(errutils.ErrMissingClayerArg)
+		log.Error(err)
+		return err
+	}
+
+	validPacks := normalizeLayers(packs)
+	if len(validPacks) == 0 {
+		validPacks = []string{defaultPack}
+	}
+
+	tmpDir := filepath.Join(originalDir, "..", moduleName+"-tmp")
+	if err = os.RemoveAll(tmpDir); err != nil {
+		log.Error(err)
+		return err
+	}
+	if err = os.MkdirAll(tmpDir, 0700); err != nil {
+		log.Error(err)
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if err = os.Chdir(tmpDir); err != nil {
+		log.Error(err)
+		return err
+	}
+	defer func() {
+		_ = os.Chdir(originalDir)
+	}()
+
+	solutionFile := moduleName + ".csolution.yml"
+	projectFile := moduleName + ".cproject.yml"
+	projectPath := filepath.Join(tmpDir, projectFile)
+
+	projectLayers, err := makeLayersRelativeToProject(validLayers, projectPath)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	solutionContent := createSolutionContent(moduleName, toolchain, device, validPacks)
+	projectContent := createProjectContent(projectLayers)
+
+	if err = os.WriteFile(solutionFile, []byte(solutionContent), 0600); err != nil {
+		log.Error(err)
+		return err
+	}
+	if err = os.WriteFile(projectFile, []byte(projectContent), 0600); err != nil {
+		log.Error(err)
+		return err
+	}
+
+	configs, err := getInstallConfigs()
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	csolutionBin, err := getToolBinary(configs.BinPath, "csolution", configs.BinExtn)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	cbuild2cmakeBin, err := getToolBinary(configs.BinPath, "cbuild2cmake", configs.BinExtn)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	runner := runnerInterface()
+	csolutionBuilder := csolution.CSolutionBuilder{
+		BuilderParams: builder.BuilderParams{
+			Runner:         runner,
+			Options:        builder.Options{Packs: true, SchemaChk: true, UpdateRte: true},
+			InputFile:      solutionFile,
+			InstallConfigs: configs,
+		},
+	}
+	if err = csolutionBuilder.InstallMissingPacks(); err != nil {
+		log.Error(err)
+		return err
+	}
+
+	_, err = runner.ExecuteCommand(csolutionBin, false, solutionFile, "convert")
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	idxFile := moduleName + ".cbuild-idx.yml"
+	_, err = runner.ExecuteCommand(cbuild2cmakeBin, false, idxFile, "--zephyr")
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	sourceModuleDir := filepath.Join(tmpDir, moduleName)
+	if _, statErr := os.Stat(sourceModuleDir); statErr == nil {
+		destinationModuleDir := filepath.Join(originalDir, moduleName)
+		if _, existsErr := os.Stat(destinationModuleDir); existsErr == nil {
+			err = errutils.New(errutils.ErrOverwritingDestination, destinationModuleDir)
+			log.Warn(err)
+		}
+
+		if err = os.RemoveAll(destinationModuleDir); err != nil {
+			log.Error(err)
+			return err
+		}
+
+		if err = os.Rename(sourceModuleDir, destinationModuleDir); err != nil {
+			log.Error(err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+var ZephyrCmd = &cobra.Command{
+	Use:   "zephyr [options]",
+	Short: "Generate Zephyr module files from clayer input",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return generateZephyrModule(cmd, args)
+	},
+}
+
+func init() {
+	ZephyrCmd.DisableFlagsInUseLine = true
+	ZephyrCmd.Flags().StringP("module", "", "", "Module name")
+	ZephyrCmd.Flags().StringSliceP("clayer", "", []string{}, "Comma-separated clayer files")
+	ZephyrCmd.Flags().StringSliceP("packs", "", []string{defaultPack}, "Comma-separated pack identifiers")
+	ZephyrCmd.Flags().StringP("toolchain", "", defaultToolchain, "Toolchain to be used")
+	ZephyrCmd.Flags().StringP("device", "", defaultDevice, "Device to be used")
+}

--- a/cmd/cbuild/commands/zephyr/zephyr.go
+++ b/cmd/cbuild/commands/zephyr/zephyr.go
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) 2026 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package zephyr
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	builder "github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder"
+	csolution "github.com/Open-CMSIS-Pack/cbuild/v2/pkg/builder/csolution"
+	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/errutils"
+	log "github.com/Open-CMSIS-Pack/cbuild/v2/pkg/logger"
+	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultToolchain = "GCC"
+	defaultDevice    = "ARMCM55"
+	defaultPack      = "ARM::Cortex_DFP"
+)
+
+var (
+	getInstallConfigs = utils.GetInstallConfigs
+	runnerInterface   = func() utils.RunnerInterface { return utils.Runner{} }
+)
+
+func createSolutionContent(moduleName string, toolchain string, device string, packs []string) string {
+	var builder strings.Builder
+	builder.WriteString("solution:\n\n")
+	builder.WriteString("  compiler: ")
+	builder.WriteString(toolchain)
+	builder.WriteString("\n\n")
+	builder.WriteString("  packs:\n")
+	for _, pack := range packs {
+		builder.WriteString("    - pack: ")
+		builder.WriteString(pack)
+		builder.WriteString("\n")
+	}
+	builder.WriteString("\n")
+	builder.WriteString("  target-types:\n")
+	builder.WriteString("    - type: ")
+	builder.WriteString(device)
+	builder.WriteString("\n")
+	builder.WriteString("      device: ")
+	builder.WriteString(device)
+	builder.WriteString("\n\n")
+	builder.WriteString("  projects:\n")
+	builder.WriteString("    - project: ")
+	builder.WriteString(moduleName)
+	builder.WriteString(".cproject.yml\n")
+
+	return builder.String()
+}
+
+func createProjectContent(clayers []string) string {
+	var builder strings.Builder
+	builder.WriteString("project:\n\n")
+	builder.WriteString("  layers:\n")
+
+	for _, clayer := range clayers {
+		builder.WriteString("    - layer: ")
+		builder.WriteString(clayer)
+		builder.WriteString("\n")
+	}
+
+	return builder.String()
+}
+
+func normalizeLayers(input []string) []string {
+	layers := make([]string, 0, len(input))
+	for _, item := range input {
+		layer := strings.TrimSpace(item)
+		if layer == "" {
+			continue
+		}
+		layers = append(layers, layer)
+	}
+	return layers
+}
+
+func isSimpleModuleName(moduleName string) bool {
+	if moduleName == "." || moduleName == ".." {
+		return false
+	}
+	if strings.ContainsAny(moduleName, `/\`) {
+		return false
+	}
+	return moduleName == filepath.Base(moduleName)
+}
+
+func resolveAndValidateLayers(input []string, cwd string) ([]string, error) {
+	layers := normalizeLayers(input)
+	resolvedLayers := make([]string, 0, len(layers))
+
+	for _, layer := range layers {
+		layerPath := layer
+		if !filepath.IsAbs(layerPath) {
+			layerPath = filepath.Join(cwd, layerPath)
+		}
+
+		absolutePath, err := filepath.Abs(layerPath)
+		if err != nil {
+			return nil, errutils.New(errutils.ErrInvalidClayerPath, layer, err)
+		}
+
+		if !strings.HasSuffix(strings.ToLower(absolutePath), ".clayer.yml") {
+			return nil, errutils.New(errutils.ErrInvalidFileExtension, layer, "*.clayer.yml")
+		}
+
+		info, err := os.Stat(absolutePath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, errutils.New(errutils.ErrFileNotExist, absolutePath)
+			}
+			return nil, errutils.New(errutils.ErrClayerAccess, absolutePath, err)
+		}
+
+		if info.IsDir() {
+			return nil, errutils.New(errutils.ErrClayerPathIsDirectory, absolutePath)
+		}
+
+		resolvedLayers = append(resolvedLayers, absolutePath)
+	}
+
+	return resolvedLayers, nil
+}
+
+func makeLayersRelativeToProject(input []string, projectFile string) ([]string, error) {
+	projectDir := filepath.Dir(projectFile)
+	relativeLayers := make([]string, 0, len(input))
+
+	for _, layer := range input {
+		relativeLayer, err := filepath.Rel(projectDir, layer)
+		if err != nil {
+			return nil, errutils.New(errutils.ErrRelativizeClayerPath, layer, projectFile, err)
+		}
+		relativeLayers = append(relativeLayers, filepath.ToSlash(relativeLayer))
+	}
+
+	return relativeLayers, nil
+}
+
+func getToolBinary(binPath string, name string, ext string) (string, error) {
+	toolPath := filepath.Join(binPath, name+ext)
+	if _, err := os.Stat(toolPath); err != nil {
+		return "", err
+	}
+	return toolPath, nil
+}
+
+func generateZephyrModule(cmd *cobra.Command, _ []string) error {
+	moduleName, _ := cmd.Flags().GetString("module")
+	toolchain, _ := cmd.Flags().GetString("toolchain")
+	device, _ := cmd.Flags().GetString("device")
+	clayers, _ := cmd.Flags().GetStringSlice("clayer")
+	packs, _ := cmd.Flags().GetStringSlice("packs")
+	originalDir, err := os.Getwd()
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	moduleName = strings.TrimSpace(moduleName)
+	if moduleName == "" {
+		err := errutils.New(errutils.ErrMissingModuleArg)
+		log.Error(err)
+		return err
+	}
+	if !isSimpleModuleName(moduleName) {
+		err := errutils.New(errutils.ErrInvalidInputArg, "--module")
+		log.Error(err)
+		return err
+	}
+
+	validLayers, err := resolveAndValidateLayers(clayers, originalDir)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	if len(validLayers) == 0 {
+		err := errutils.New(errutils.ErrMissingClayerArg)
+		log.Error(err)
+		return err
+	}
+
+	validPacks := normalizeLayers(packs)
+	if len(validPacks) == 0 {
+		validPacks = []string{defaultPack}
+	}
+
+	tmpDir := filepath.Join(originalDir, moduleName+"-tmp")
+	if err = os.RemoveAll(tmpDir); err != nil {
+		log.Error(err)
+		return err
+	}
+	if err = os.MkdirAll(tmpDir, 0700); err != nil {
+		log.Error(err)
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if err = os.Chdir(tmpDir); err != nil {
+		log.Error(err)
+		return err
+	}
+	defer func() {
+		_ = os.Chdir(originalDir)
+	}()
+
+	solutionFile := moduleName + ".csolution.yml"
+	projectFile := moduleName + ".cproject.yml"
+	projectPath := filepath.Join(tmpDir, projectFile)
+
+	projectLayers, err := makeLayersRelativeToProject(validLayers, projectPath)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	solutionContent := createSolutionContent(moduleName, toolchain, device, validPacks)
+	projectContent := createProjectContent(projectLayers)
+
+	if err = os.WriteFile(solutionFile, []byte(solutionContent), 0600); err != nil {
+		log.Error(err)
+		return err
+	}
+	if err = os.WriteFile(projectFile, []byte(projectContent), 0600); err != nil {
+		log.Error(err)
+		return err
+	}
+
+	configs, err := getInstallConfigs()
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	csolutionBin, err := getToolBinary(configs.BinPath, "csolution", configs.BinExtn)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	cbuild2cmakeBin, err := getToolBinary(configs.BinPath, "cbuild2cmake", configs.BinExtn)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	runner := runnerInterface()
+	csolutionBuilder := csolution.CSolutionBuilder{
+		BuilderParams: builder.BuilderParams{
+			Runner:         runner,
+			Options:        builder.Options{Packs: true, SchemaChk: true, UpdateRte: true},
+			InputFile:      solutionFile,
+			InstallConfigs: configs,
+		},
+	}
+	if err = csolutionBuilder.InstallMissingPacks(); err != nil {
+		log.Error(err)
+		return err
+	}
+
+	_, err = runner.ExecuteCommand(csolutionBin, false, "convert", solutionFile)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	idxFile := moduleName + ".cbuild-idx.yml"
+	_, err = runner.ExecuteCommand(cbuild2cmakeBin, false, idxFile, "--zephyr")
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
+	sourceModuleDir := filepath.Join(tmpDir, moduleName)
+	if _, statErr := os.Stat(sourceModuleDir); statErr != nil {
+		if os.IsNotExist(statErr) {
+			err = errutils.New(errutils.ErrPathNotExist, sourceModuleDir)
+		} else {
+			err = statErr
+		}
+		log.Error(err)
+		return err
+	}
+
+	destinationModuleDir := filepath.Join(originalDir, moduleName)
+	if _, existsErr := os.Stat(destinationModuleDir); existsErr == nil {
+		log.Warn("overwriting existing destination:", destinationModuleDir)
+	}
+
+	if err = os.RemoveAll(destinationModuleDir); err != nil {
+		log.Error(err)
+		return err
+	}
+
+	if err = os.Rename(sourceModuleDir, destinationModuleDir); err != nil {
+		log.Error(err)
+		return err
+	}
+
+	return nil
+}
+
+var ZephyrCmd = &cobra.Command{
+	Use:   "zephyr [options]",
+	Short: "Generate Zephyr module files from clayer input",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return generateZephyrModule(cmd, args)
+	},
+}
+
+func init() {
+	ZephyrCmd.DisableFlagsInUseLine = true
+	ZephyrCmd.Flags().StringP("module", "", "", "Module name")
+	ZephyrCmd.Flags().StringSliceP("clayer", "", []string{}, "Comma-separated clayer files")
+	ZephyrCmd.Flags().StringSliceP("packs", "", []string{defaultPack}, "Comma-separated pack identifiers")
+	ZephyrCmd.Flags().StringP("toolchain", "", defaultToolchain, "Toolchain to be used")
+	ZephyrCmd.Flags().StringP("device", "", defaultDevice, "Device to be used")
+}

--- a/cmd/cbuild/commands/zephyr/zephyr.go
+++ b/cmd/cbuild/commands/zephyr/zephyr.go
@@ -27,52 +27,52 @@ const (
 
 var (
 	getInstallConfigs = utils.GetInstallConfigs
-	runnerInterface   = func() utils.RunnerInterface { return utils.Runner{} }
+	newRunner         = func() utils.RunnerInterface { return utils.Runner{} }
 )
 
 func createSolutionContent(moduleName string, toolchain string, device string, packs []string) string {
-	var builder strings.Builder
-	builder.WriteString("solution:\n\n")
-	builder.WriteString("  compiler: ")
-	builder.WriteString(toolchain)
-	builder.WriteString("\n\n")
-	builder.WriteString("  packs:\n")
+	var sb strings.Builder
+	sb.WriteString("solution:\n\n")
+	sb.WriteString("  compiler: ")
+	sb.WriteString(toolchain)
+	sb.WriteString("\n\n")
+	sb.WriteString("  packs:\n")
 	for _, pack := range packs {
-		builder.WriteString("    - pack: ")
-		builder.WriteString(pack)
-		builder.WriteString("\n")
+		sb.WriteString("    - pack: ")
+		sb.WriteString(pack)
+		sb.WriteString("\n")
 	}
-	builder.WriteString("\n")
-	builder.WriteString("  target-types:\n")
-	builder.WriteString("    - type: ")
-	builder.WriteString(device)
-	builder.WriteString("\n")
-	builder.WriteString("      device: ")
-	builder.WriteString(device)
-	builder.WriteString("\n\n")
-	builder.WriteString("  projects:\n")
-	builder.WriteString("    - project: ")
-	builder.WriteString(moduleName)
-	builder.WriteString(".cproject.yml\n")
+	sb.WriteString("\n")
+	sb.WriteString("  target-types:\n")
+	sb.WriteString("    - type: ")
+	sb.WriteString(device)
+	sb.WriteString("\n")
+	sb.WriteString("      device: ")
+	sb.WriteString(device)
+	sb.WriteString("\n\n")
+	sb.WriteString("  projects:\n")
+	sb.WriteString("    - project: ")
+	sb.WriteString(moduleName)
+	sb.WriteString(".cproject.yml\n")
 
-	return builder.String()
+	return sb.String()
 }
 
 func createProjectContent(clayers []string) string {
-	var builder strings.Builder
-	builder.WriteString("project:\n\n")
-	builder.WriteString("  layers:\n")
+	var sb strings.Builder
+	sb.WriteString("project:\n\n")
+	sb.WriteString("  layers:\n")
 
 	for _, clayer := range clayers {
-		builder.WriteString("    - layer: ")
-		builder.WriteString(clayer)
-		builder.WriteString("\n")
+		sb.WriteString("    - layer: ")
+		sb.WriteString(clayer)
+		sb.WriteString("\n")
 	}
 
-	return builder.String()
+	return sb.String()
 }
 
-func normalizeLayers(input []string) []string {
+func trimAndDropEmpty(input []string) []string {
 	layers := make([]string, 0, len(input))
 	for _, item := range input {
 		layer := strings.TrimSpace(item)
@@ -95,7 +95,7 @@ func isSimpleModuleName(moduleName string) bool {
 }
 
 func resolveAndValidateLayers(input []string, cwd string) ([]string, error) {
-	layers := normalizeLayers(input)
+	layers := trimAndDropEmpty(input)
 	resolvedLayers := make([]string, 0, len(layers))
 
 	for _, layer := range layers {
@@ -149,7 +149,7 @@ func makeLayersRelativeToProject(input []string, projectFile string) ([]string, 
 func getToolBinary(binPath string, name string, ext string) (string, error) {
 	toolPath := filepath.Join(binPath, name+ext)
 	if _, err := os.Stat(toolPath); err != nil {
-		return "", err
+		return "", errutils.New(errutils.ErrBinaryNotFound, name+ext, "at '"+toolPath+"'")
 	}
 	return toolPath, nil
 }
@@ -189,7 +189,7 @@ func generateZephyrModule(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	validPacks := normalizeLayers(packs)
+	validPacks := trimAndDropEmpty(packs)
 	if len(validPacks) == 0 {
 		validPacks = []string{defaultPack}
 	}
@@ -253,7 +253,7 @@ func generateZephyrModule(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	runner := runnerInterface()
+	runner := newRunner()
 	csolutionBuilder := csolution.CSolutionBuilder{
 		BuilderParams: builder.BuilderParams{
 			Runner:         runner,

--- a/cmd/cbuild/commands/zephyr/zephyr_test.go
+++ b/cmd/cbuild/commands/zephyr/zephyr_test.go
@@ -228,6 +228,20 @@ func TestValidation(t *testing.T) {
 			t.Fatal("expected error when clayer is missing")
 		}
 	})
+
+	t.Run("rejects invalid module names", func(t *testing.T) {
+		invalidNames := []string{".", "..", "../demo", "demo/test", "demo\\test"}
+		for _, name := range invalidNames {
+			cmd := testZephyrCmd(t, name, []string{clayer}, []string{defaultPack})
+			err := generateZephyrModule(cmd, nil)
+			if err == nil {
+				t.Fatalf("expected error for invalid module name %q", name)
+			}
+			if !strings.Contains(err.Error(), "invalid input argument") {
+				t.Fatalf("expected invalid input argument error for %q, got %v", name, err)
+			}
+		}
+	})
 }
 
 func TestZephyrModuleGeneration(t *testing.T) {
@@ -284,7 +298,7 @@ func TestZephyrModuleGeneration(t *testing.T) {
 	joined := strings.Join(fake.commands, "\n")
 	listIndex := strings.Index(joined, "csolution list packs")
 	addIndex := strings.Index(joined, "cpackget add Vendor::TestPack@1.0.0")
-	convertIndex := strings.Index(joined, "csolution demo.csolution.yml convert")
+	convertIndex := strings.Index(joined, "csolution convert demo.csolution.yml")
 	cmakeIndex := strings.Index(joined, "cbuild2cmake demo.cbuild-idx.yml --zephyr")
 
 	if listIndex == -1 || addIndex == -1 || convertIndex == -1 || cmakeIndex == -1 {
@@ -298,5 +312,44 @@ func TestZephyrModuleGeneration(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(destinationModuleDir, "old.txt")); !os.IsNotExist(err) {
 		t.Fatalf("expected old destination content to be replaced, got err: %v", err)
+	}
+}
+
+func TestZephyrModuleGenerationFailsWhenModuleDirMissing(t *testing.T) {
+	workDir := withTempWorkingDir(t)
+
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0700); err != nil {
+		t.Fatalf("failed to create bin dir: %v", err)
+	}
+	createTool(t, binDir, "csolution")
+	createTool(t, binDir, "cbuild2cmake")
+	createTool(t, binDir, "cpackget")
+
+	clayer := filepath.Join(workDir, "input.clayer.yml")
+	if err := os.WriteFile(clayer, []byte("layer"), 0600); err != nil {
+		t.Fatalf("failed to write clayer: %v", err)
+	}
+
+	oldGetInstallConfigs := getInstallConfigs
+	oldRunnerInterface := runnerInterface
+	t.Cleanup(func() {
+		getInstallConfigs = oldGetInstallConfigs
+		runnerInterface = oldRunnerInterface
+	})
+
+	getInstallConfigs = func() (utils.Configurations, error) {
+		return utils.Configurations{BinPath: binDir, EtcPath: workDir, BinExtn: ""}, nil
+	}
+	fake := &fakeRunner{}
+	runnerInterface = func() utils.RunnerInterface { return fake }
+
+	cmd := testZephyrCmd(t, "demo", []string{clayer}, []string{defaultPack})
+	err := generateZephyrModule(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error when generated module directory is missing")
+	}
+	if !strings.Contains(err.Error(), "path does not exist") {
+		t.Fatalf("expected missing path error, got %v", err)
 	}
 }

--- a/cmd/cbuild/commands/zephyr/zephyr_test.go
+++ b/cmd/cbuild/commands/zephyr/zephyr_test.go
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2026 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package zephyr
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+type fakeRunner struct {
+	commands []string
+	onExec   func(entry string) error
+}
+
+func (f *fakeRunner) ExecuteCommand(program string, _ bool, args ...string) (string, error) {
+	entry := filepath.Base(program)
+	if len(args) > 0 {
+		entry += " " + strings.Join(args, " ")
+	}
+	f.commands = append(f.commands, entry)
+	if f.onExec != nil {
+		if err := f.onExec(entry); err != nil {
+			return "", err
+		}
+	}
+
+	if strings.Contains(entry, "list packs") {
+		return "Vendor::TestPack@1.0.0", nil
+	}
+	return "", nil
+}
+
+func testZephyrCmd(t *testing.T, moduleName string, clayers []string, packs []string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.Flags().String("module", moduleName, "")
+	cmd.Flags().String("toolchain", defaultToolchain, "")
+	cmd.Flags().String("device", defaultDevice, "")
+	cmd.Flags().StringSlice("clayer", clayers, "")
+	cmd.Flags().StringSlice("packs", packs, "")
+	return cmd
+}
+
+func createTool(t *testing.T, binDir string, name string) {
+	t.Helper()
+	tool := filepath.Join(binDir, name)
+	if err := os.WriteFile(tool, []byte(""), 0600); err != nil {
+		t.Fatalf("failed to create %s: %v", name, err)
+	}
+}
+
+func withTempWorkingDir(t *testing.T) string {
+	t.Helper()
+	tempDir := t.TempDir()
+	workDir := filepath.Join(tempDir, "workspace", "project")
+	if err := os.MkdirAll(workDir, 0700); err != nil {
+		t.Fatalf("failed to create work dir: %v", err)
+	}
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	if err = os.Chdir(workDir); err != nil {
+		t.Fatalf("failed to set cwd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(originalDir)
+	})
+	return workDir
+}
+
+func TestResolveAndValidateLayers(t *testing.T) {
+	tempDir := t.TempDir()
+
+	relativeFile := filepath.Join(tempDir, "test.clayer.yml")
+	if err := os.WriteFile(relativeFile, []byte("layer"), 0600); err != nil {
+		t.Fatalf("failed to create test clayer file: %v", err)
+	}
+
+	absoluteFile, err := filepath.Abs(relativeFile)
+	if err != nil {
+		t.Fatalf("failed to resolve absolute test path: %v", err)
+	}
+
+	t.Run("resolves relative file to absolute", func(t *testing.T) {
+		layers, err := resolveAndValidateLayers([]string{"test.clayer.yml"}, tempDir)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(layers) != 1 {
+			t.Fatalf("expected 1 layer, got %d", len(layers))
+		}
+		if layers[0] != absoluteFile {
+			t.Fatalf("expected %s, got %s", absoluteFile, layers[0])
+		}
+	})
+
+	t.Run("accepts absolute path", func(t *testing.T) {
+		layers, err := resolveAndValidateLayers([]string{absoluteFile}, tempDir)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(layers) != 1 {
+			t.Fatalf("expected 1 layer, got %d", len(layers))
+		}
+		if layers[0] != absoluteFile {
+			t.Fatalf("expected %s, got %s", absoluteFile, layers[0])
+		}
+	})
+
+	t.Run("rejects missing file", func(t *testing.T) {
+		_, err := resolveAndValidateLayers([]string{"missing.clayer.yml"}, tempDir)
+		if err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+
+	t.Run("rejects invalid extension", func(t *testing.T) {
+		invalid := filepath.Join(tempDir, "bad.yml")
+		if err := os.WriteFile(invalid, []byte("layer"), 0600); err != nil {
+			t.Fatalf("failed to create invalid test file: %v", err)
+		}
+
+		_, err := resolveAndValidateLayers([]string{"bad.yml"}, tempDir)
+		if err == nil {
+			t.Fatal("expected error for invalid extension")
+		}
+	})
+}
+
+func TestMakeLayersRelativeToProject(t *testing.T) {
+	tempDir := t.TempDir()
+	layersDir := filepath.Join(tempDir, "layers")
+	if err := os.MkdirAll(layersDir, 0700); err != nil {
+		t.Fatalf("failed to create layers dir: %v", err)
+	}
+
+	clayer := filepath.Join(layersDir, "input.clayer.yml")
+	if err := os.WriteFile(clayer, []byte("layer"), 0600); err != nil {
+		t.Fatalf("failed to create clayer file: %v", err)
+	}
+
+	t.Run("converts absolute clayer to path relative to cproject", func(t *testing.T) {
+		projectDir := filepath.Join(tempDir, "module")
+		if err := os.MkdirAll(projectDir, 0700); err != nil {
+			t.Fatalf("failed to create module dir: %v", err)
+		}
+
+		projectFile := filepath.Join(projectDir, "demo.cproject.yml")
+		relative, err := makeLayersRelativeToProject([]string{clayer}, projectFile)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if len(relative) != 1 {
+			t.Fatalf("expected 1 layer, got %d", len(relative))
+		}
+
+		expected := filepath.Join("..", "layers", "input.clayer.yml")
+		if relative[0] != filepath.ToSlash(expected) {
+			t.Fatalf("expected %s, got %s", expected, relative[0])
+		}
+	})
+
+	t.Run("keeps filename when clayer in same dir as cproject", func(t *testing.T) {
+		projectDir := filepath.Join(tempDir, "same")
+		if err := os.MkdirAll(projectDir, 0700); err != nil {
+			t.Fatalf("failed to create same dir: %v", err)
+		}
+
+		sameLayer := filepath.Join(projectDir, "same.clayer.yml")
+		if err := os.WriteFile(sameLayer, []byte("layer"), 0600); err != nil {
+			t.Fatalf("failed to create same-dir layer: %v", err)
+		}
+
+		projectFile := filepath.Join(projectDir, "demo.cproject.yml")
+		relative, err := makeLayersRelativeToProject([]string{sameLayer}, projectFile)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if len(relative) != 1 {
+			t.Fatalf("expected 1 layer, got %d", len(relative))
+		}
+
+		if relative[0] != "same.clayer.yml" {
+			t.Fatalf("expected same.clayer.yml, got %s", relative[0])
+		}
+	})
+}
+
+func TestNormalizeLayers(t *testing.T) {
+	layers := normalizeLayers([]string{"  a.clayer.yml ", "", "  ", "b.clayer.yml"})
+	if len(layers) != 2 {
+		t.Fatalf("expected 2 layers, got %d", len(layers))
+	}
+	if layers[0] != "a.clayer.yml" || layers[1] != "b.clayer.yml" {
+		t.Fatalf("unexpected layers: %v", layers)
+	}
+}
+
+func TestValidation(t *testing.T) {
+	workDir := withTempWorkingDir(t)
+	clayer := filepath.Join(workDir, "ok.clayer.yml")
+	if err := os.WriteFile(clayer, []byte("layer"), 0600); err != nil {
+		t.Fatalf("failed to write clayer: %v", err)
+	}
+
+	t.Run("requires module", func(t *testing.T) {
+		cmd := testZephyrCmd(t, "", []string{clayer}, []string{defaultPack})
+		if err := generateZephyrModule(cmd, nil); err == nil {
+			t.Fatal("expected error when module is missing")
+		}
+	})
+
+	t.Run("requires at least one clayer", func(t *testing.T) {
+		cmd := testZephyrCmd(t, "demo", []string{}, []string{defaultPack})
+		if err := generateZephyrModule(cmd, nil); err == nil {
+			t.Fatal("expected error when clayer is missing")
+		}
+	})
+}
+
+func TestZephyrModuleGeneration(t *testing.T) {
+	workDir := withTempWorkingDir(t)
+	destinationModuleDir := filepath.Join(workDir, "demo")
+	if err := os.MkdirAll(destinationModuleDir, 0700); err != nil {
+		t.Fatalf("failed to create destination module dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(destinationModuleDir, "old.txt"), []byte("old"), 0600); err != nil {
+		t.Fatalf("failed to create destination marker file: %v", err)
+	}
+
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0700); err != nil {
+		t.Fatalf("failed to create bin dir: %v", err)
+	}
+	createTool(t, binDir, "csolution")
+	createTool(t, binDir, "cbuild2cmake")
+	createTool(t, binDir, "cpackget")
+
+	clayer := filepath.Join(workDir, "input.clayer.yml")
+	if err := os.WriteFile(clayer, []byte("layer"), 0600); err != nil {
+		t.Fatalf("failed to write clayer: %v", err)
+	}
+
+	oldGetInstallConfigs := getInstallConfigs
+	oldRunnerInterface := runnerInterface
+	t.Cleanup(func() {
+		getInstallConfigs = oldGetInstallConfigs
+		runnerInterface = oldRunnerInterface
+	})
+
+	getInstallConfigs = func() (utils.Configurations, error) {
+		return utils.Configurations{BinPath: binDir, EtcPath: workDir, BinExtn: ""}, nil
+	}
+	fake := &fakeRunner{onExec: func(entry string) error {
+		if strings.Contains(entry, "cbuild2cmake demo.cbuild-idx.yml --zephyr") {
+			if err := os.MkdirAll("demo", 0700); err != nil {
+				return err
+			}
+			if err := os.WriteFile(filepath.Join("demo", "new.txt"), []byte("new"), 0600); err != nil {
+				return err
+			}
+		}
+		return nil
+	}}
+	runnerInterface = func() utils.RunnerInterface { return fake }
+
+	cmd := testZephyrCmd(t, "demo", []string{clayer}, []string{defaultPack})
+	if err := generateZephyrModule(cmd, nil); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	joined := strings.Join(fake.commands, "\n")
+	listIndex := strings.Index(joined, "csolution list packs")
+	addIndex := strings.Index(joined, "cpackget add Vendor::TestPack@1.0.0")
+	convertIndex := strings.Index(joined, "csolution demo.csolution.yml convert")
+	cmakeIndex := strings.Index(joined, "cbuild2cmake demo.cbuild-idx.yml --zephyr")
+
+	if listIndex == -1 || addIndex == -1 || convertIndex == -1 || cmakeIndex == -1 {
+		t.Fatalf("unexpected command sequence:\n%s", joined)
+	}
+	if listIndex >= addIndex || addIndex >= convertIndex || convertIndex >= cmakeIndex {
+		t.Fatalf("commands are not in expected order:\n%s", joined)
+	}
+	if _, err := os.Stat(filepath.Join(destinationModuleDir, "new.txt")); err != nil {
+		t.Fatalf("expected generated module to be moved to destination, got: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destinationModuleDir, "old.txt")); !os.IsNotExist(err) {
+		t.Fatalf("expected old destination content to be replaced, got err: %v", err)
+	}
+}

--- a/cmd/cbuild/commands/zephyr/zephyr_test.go
+++ b/cmd/cbuild/commands/zephyr/zephyr_test.go
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2026 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package zephyr
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Open-CMSIS-Pack/cbuild/v2/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+type fakeRunner struct {
+	commands []string
+	onExec   func(entry string) error
+}
+
+func (f *fakeRunner) ExecuteCommand(program string, _ bool, args ...string) (string, error) {
+	entry := filepath.Base(program)
+	if len(args) > 0 {
+		entry += " " + strings.Join(args, " ")
+	}
+	f.commands = append(f.commands, entry)
+	if f.onExec != nil {
+		if err := f.onExec(entry); err != nil {
+			return "", err
+		}
+	}
+
+	if strings.Contains(entry, "list packs") {
+		return "Vendor::TestPack@1.0.0", nil
+	}
+	return "", nil
+}
+
+func testZephyrCmd(t *testing.T, moduleName string, clayers []string, packs []string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.Flags().String("module", moduleName, "")
+	cmd.Flags().String("toolchain", defaultToolchain, "")
+	cmd.Flags().String("device", defaultDevice, "")
+	cmd.Flags().StringSlice("clayer", clayers, "")
+	cmd.Flags().StringSlice("packs", packs, "")
+	return cmd
+}
+
+func createTool(t *testing.T, binDir string, name string) {
+	t.Helper()
+	tool := filepath.Join(binDir, name)
+	if err := os.WriteFile(tool, []byte(""), 0600); err != nil {
+		t.Fatalf("failed to create %s: %v", name, err)
+	}
+}
+
+func withTempWorkingDir(t *testing.T) string {
+	t.Helper()
+	tempDir := t.TempDir()
+	workDir := filepath.Join(tempDir, "workspace", "project")
+	if err := os.MkdirAll(workDir, 0700); err != nil {
+		t.Fatalf("failed to create work dir: %v", err)
+	}
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	if err = os.Chdir(workDir); err != nil {
+		t.Fatalf("failed to set cwd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(originalDir)
+	})
+	return workDir
+}
+
+func TestResolveAndValidateLayers(t *testing.T) {
+	tempDir := t.TempDir()
+
+	relativeFile := filepath.Join(tempDir, "test.clayer.yml")
+	if err := os.WriteFile(relativeFile, []byte("layer"), 0600); err != nil {
+		t.Fatalf("failed to create test clayer file: %v", err)
+	}
+
+	absoluteFile, err := filepath.Abs(relativeFile)
+	if err != nil {
+		t.Fatalf("failed to resolve absolute test path: %v", err)
+	}
+
+	t.Run("resolves relative file to absolute", func(t *testing.T) {
+		layers, err := resolveAndValidateLayers([]string{"test.clayer.yml"}, tempDir)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(layers) != 1 {
+			t.Fatalf("expected 1 layer, got %d", len(layers))
+		}
+		if layers[0] != absoluteFile {
+			t.Fatalf("expected %s, got %s", absoluteFile, layers[0])
+		}
+	})
+
+	t.Run("accepts absolute path", func(t *testing.T) {
+		layers, err := resolveAndValidateLayers([]string{absoluteFile}, tempDir)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(layers) != 1 {
+			t.Fatalf("expected 1 layer, got %d", len(layers))
+		}
+		if layers[0] != absoluteFile {
+			t.Fatalf("expected %s, got %s", absoluteFile, layers[0])
+		}
+	})
+
+	t.Run("rejects missing file", func(t *testing.T) {
+		_, err := resolveAndValidateLayers([]string{"missing.clayer.yml"}, tempDir)
+		if err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+
+	t.Run("rejects invalid extension", func(t *testing.T) {
+		invalid := filepath.Join(tempDir, "bad.yml")
+		if err := os.WriteFile(invalid, []byte("layer"), 0600); err != nil {
+			t.Fatalf("failed to create invalid test file: %v", err)
+		}
+
+		_, err := resolveAndValidateLayers([]string{"bad.yml"}, tempDir)
+		if err == nil {
+			t.Fatal("expected error for invalid extension")
+		}
+	})
+}
+
+func TestMakeLayersRelativeToProject(t *testing.T) {
+	tempDir := t.TempDir()
+	layersDir := filepath.Join(tempDir, "layers")
+	if err := os.MkdirAll(layersDir, 0700); err != nil {
+		t.Fatalf("failed to create layers dir: %v", err)
+	}
+
+	clayer := filepath.Join(layersDir, "input.clayer.yml")
+	if err := os.WriteFile(clayer, []byte("layer"), 0600); err != nil {
+		t.Fatalf("failed to create clayer file: %v", err)
+	}
+
+	t.Run("converts absolute clayer to path relative to cproject", func(t *testing.T) {
+		projectDir := filepath.Join(tempDir, "module")
+		if err := os.MkdirAll(projectDir, 0700); err != nil {
+			t.Fatalf("failed to create module dir: %v", err)
+		}
+
+		projectFile := filepath.Join(projectDir, "demo.cproject.yml")
+		relative, err := makeLayersRelativeToProject([]string{clayer}, projectFile)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if len(relative) != 1 {
+			t.Fatalf("expected 1 layer, got %d", len(relative))
+		}
+
+		expected := filepath.Join("..", "layers", "input.clayer.yml")
+		if relative[0] != filepath.ToSlash(expected) {
+			t.Fatalf("expected %s, got %s", expected, relative[0])
+		}
+	})
+
+	t.Run("keeps filename when clayer in same dir as cproject", func(t *testing.T) {
+		projectDir := filepath.Join(tempDir, "same")
+		if err := os.MkdirAll(projectDir, 0700); err != nil {
+			t.Fatalf("failed to create same dir: %v", err)
+		}
+
+		sameLayer := filepath.Join(projectDir, "same.clayer.yml")
+		if err := os.WriteFile(sameLayer, []byte("layer"), 0600); err != nil {
+			t.Fatalf("failed to create same-dir layer: %v", err)
+		}
+
+		projectFile := filepath.Join(projectDir, "demo.cproject.yml")
+		relative, err := makeLayersRelativeToProject([]string{sameLayer}, projectFile)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if len(relative) != 1 {
+			t.Fatalf("expected 1 layer, got %d", len(relative))
+		}
+
+		if relative[0] != "same.clayer.yml" {
+			t.Fatalf("expected same.clayer.yml, got %s", relative[0])
+		}
+	})
+}
+
+func TestNormalizeLayers(t *testing.T) {
+	layers := normalizeLayers([]string{"  a.clayer.yml ", "", "  ", "b.clayer.yml"})
+	if len(layers) != 2 {
+		t.Fatalf("expected 2 layers, got %d", len(layers))
+	}
+	if layers[0] != "a.clayer.yml" || layers[1] != "b.clayer.yml" {
+		t.Fatalf("unexpected layers: %v", layers)
+	}
+}
+
+func TestValidation(t *testing.T) {
+	workDir := withTempWorkingDir(t)
+	clayer := filepath.Join(workDir, "ok.clayer.yml")
+	if err := os.WriteFile(clayer, []byte("layer"), 0600); err != nil {
+		t.Fatalf("failed to write clayer: %v", err)
+	}
+
+	t.Run("requires module", func(t *testing.T) {
+		cmd := testZephyrCmd(t, "", []string{clayer}, []string{defaultPack})
+		if err := generateZephyrModule(cmd, nil); err == nil {
+			t.Fatal("expected error when module is missing")
+		}
+	})
+
+	t.Run("requires at least one clayer", func(t *testing.T) {
+		cmd := testZephyrCmd(t, "demo", []string{}, []string{defaultPack})
+		if err := generateZephyrModule(cmd, nil); err == nil {
+			t.Fatal("expected error when clayer is missing")
+		}
+	})
+
+	t.Run("rejects invalid module names", func(t *testing.T) {
+		invalidNames := []string{".", "..", "../demo", "demo/test", "demo\\test"}
+		for _, name := range invalidNames {
+			cmd := testZephyrCmd(t, name, []string{clayer}, []string{defaultPack})
+			err := generateZephyrModule(cmd, nil)
+			if err == nil {
+				t.Fatalf("expected error for invalid module name %q", name)
+			}
+			if !strings.Contains(err.Error(), "invalid input argument") {
+				t.Fatalf("expected invalid input argument error for %q, got %v", name, err)
+			}
+		}
+	})
+}
+
+func TestZephyrModuleGeneration(t *testing.T) {
+	workDir := withTempWorkingDir(t)
+	destinationModuleDir := filepath.Join(workDir, "demo")
+	if err := os.MkdirAll(destinationModuleDir, 0700); err != nil {
+		t.Fatalf("failed to create destination module dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(destinationModuleDir, "old.txt"), []byte("old"), 0600); err != nil {
+		t.Fatalf("failed to create destination marker file: %v", err)
+	}
+
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0700); err != nil {
+		t.Fatalf("failed to create bin dir: %v", err)
+	}
+	createTool(t, binDir, "csolution")
+	createTool(t, binDir, "cbuild2cmake")
+	createTool(t, binDir, "cpackget")
+
+	clayer := filepath.Join(workDir, "input.clayer.yml")
+	if err := os.WriteFile(clayer, []byte("layer"), 0600); err != nil {
+		t.Fatalf("failed to write clayer: %v", err)
+	}
+
+	oldGetInstallConfigs := getInstallConfigs
+	oldRunnerInterface := runnerInterface
+	t.Cleanup(func() {
+		getInstallConfigs = oldGetInstallConfigs
+		runnerInterface = oldRunnerInterface
+	})
+
+	getInstallConfigs = func() (utils.Configurations, error) {
+		return utils.Configurations{BinPath: binDir, EtcPath: workDir, BinExtn: ""}, nil
+	}
+	fake := &fakeRunner{onExec: func(entry string) error {
+		if strings.Contains(entry, "cbuild2cmake demo.cbuild-idx.yml --zephyr") {
+			if err := os.MkdirAll("demo", 0700); err != nil {
+				return err
+			}
+			if err := os.WriteFile(filepath.Join("demo", "new.txt"), []byte("new"), 0600); err != nil {
+				return err
+			}
+		}
+		return nil
+	}}
+	runnerInterface = func() utils.RunnerInterface { return fake }
+
+	cmd := testZephyrCmd(t, "demo", []string{clayer}, []string{defaultPack})
+	if err := generateZephyrModule(cmd, nil); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	joined := strings.Join(fake.commands, "\n")
+	listIndex := strings.Index(joined, "csolution list packs")
+	addIndex := strings.Index(joined, "cpackget add Vendor::TestPack@1.0.0")
+	convertIndex := strings.Index(joined, "csolution convert demo.csolution.yml")
+	cmakeIndex := strings.Index(joined, "cbuild2cmake demo.cbuild-idx.yml --zephyr")
+
+	if listIndex == -1 || addIndex == -1 || convertIndex == -1 || cmakeIndex == -1 {
+		t.Fatalf("unexpected command sequence:\n%s", joined)
+	}
+	if listIndex >= addIndex || addIndex >= convertIndex || convertIndex >= cmakeIndex {
+		t.Fatalf("commands are not in expected order:\n%s", joined)
+	}
+	if _, err := os.Stat(filepath.Join(destinationModuleDir, "new.txt")); err != nil {
+		t.Fatalf("expected generated module to be moved to destination, got: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destinationModuleDir, "old.txt")); !os.IsNotExist(err) {
+		t.Fatalf("expected old destination content to be replaced, got err: %v", err)
+	}
+}
+
+func TestZephyrModuleGenerationFailsWhenModuleDirMissing(t *testing.T) {
+	workDir := withTempWorkingDir(t)
+
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0700); err != nil {
+		t.Fatalf("failed to create bin dir: %v", err)
+	}
+	createTool(t, binDir, "csolution")
+	createTool(t, binDir, "cbuild2cmake")
+	createTool(t, binDir, "cpackget")
+
+	clayer := filepath.Join(workDir, "input.clayer.yml")
+	if err := os.WriteFile(clayer, []byte("layer"), 0600); err != nil {
+		t.Fatalf("failed to write clayer: %v", err)
+	}
+
+	oldGetInstallConfigs := getInstallConfigs
+	oldRunnerInterface := runnerInterface
+	t.Cleanup(func() {
+		getInstallConfigs = oldGetInstallConfigs
+		runnerInterface = oldRunnerInterface
+	})
+
+	getInstallConfigs = func() (utils.Configurations, error) {
+		return utils.Configurations{BinPath: binDir, EtcPath: workDir, BinExtn: ""}, nil
+	}
+	fake := &fakeRunner{}
+	runnerInterface = func() utils.RunnerInterface { return fake }
+
+	cmd := testZephyrCmd(t, "demo", []string{clayer}, []string{defaultPack})
+	err := generateZephyrModule(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error when generated module directory is missing")
+	}
+	if !strings.Contains(err.Error(), "path does not exist") {
+		t.Fatalf("expected missing path error, got %v", err)
+	}
+}

--- a/cmd/cbuild/commands/zephyr/zephyr_test.go
+++ b/cmd/cbuild/commands/zephyr/zephyr_test.go
@@ -198,8 +198,8 @@ func TestMakeLayersRelativeToProject(t *testing.T) {
 	})
 }
 
-func TestNormalizeLayers(t *testing.T) {
-	layers := normalizeLayers([]string{"  a.clayer.yml ", "", "  ", "b.clayer.yml"})
+func TestTrimAndDropEmpty(t *testing.T) {
+	layers := trimAndDropEmpty([]string{"  a.clayer.yml ", "", "  ", "b.clayer.yml"})
 	if len(layers) != 2 {
 		t.Fatalf("expected 2 layers, got %d", len(layers))
 	}
@@ -268,10 +268,10 @@ func TestZephyrModuleGeneration(t *testing.T) {
 	}
 
 	oldGetInstallConfigs := getInstallConfigs
-	oldRunnerInterface := runnerInterface
+	oldNewRunner := newRunner
 	t.Cleanup(func() {
 		getInstallConfigs = oldGetInstallConfigs
-		runnerInterface = oldRunnerInterface
+		newRunner = oldNewRunner
 	})
 
 	getInstallConfigs = func() (utils.Configurations, error) {
@@ -288,7 +288,7 @@ func TestZephyrModuleGeneration(t *testing.T) {
 		}
 		return nil
 	}}
-	runnerInterface = func() utils.RunnerInterface { return fake }
+	newRunner = func() utils.RunnerInterface { return fake }
 
 	cmd := testZephyrCmd(t, "demo", []string{clayer}, []string{defaultPack})
 	if err := generateZephyrModule(cmd, nil); err != nil {
@@ -332,17 +332,17 @@ func TestZephyrModuleGenerationFailsWhenModuleDirMissing(t *testing.T) {
 	}
 
 	oldGetInstallConfigs := getInstallConfigs
-	oldRunnerInterface := runnerInterface
+	oldNewRunner := newRunner
 	t.Cleanup(func() {
 		getInstallConfigs = oldGetInstallConfigs
-		runnerInterface = oldRunnerInterface
+		newRunner = oldNewRunner
 	})
 
 	getInstallConfigs = func() (utils.Configurations, error) {
 		return utils.Configurations{BinPath: binDir, EtcPath: workDir, BinExtn: ""}, nil
 	}
 	fake := &fakeRunner{}
-	runnerInterface = func() utils.RunnerInterface { return fake }
+	newRunner = func() utils.RunnerInterface { return fake }
 
 	cmd := testZephyrCmd(t, "demo", []string{clayer}, []string{defaultPack})
 	err := generateZephyrModule(cmd, nil)
@@ -351,5 +351,39 @@ func TestZephyrModuleGenerationFailsWhenModuleDirMissing(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "path does not exist") {
 		t.Fatalf("expected missing path error, got %v", err)
+	}
+}
+
+func TestZephyrModuleGenerationFailsWhenToolBinaryMissing(t *testing.T) {
+	workDir := withTempWorkingDir(t)
+
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0700); err != nil {
+		t.Fatalf("failed to create bin dir: %v", err)
+	}
+	createTool(t, binDir, "cbuild2cmake")
+	createTool(t, binDir, "cpackget")
+
+	clayer := filepath.Join(workDir, "input.clayer.yml")
+	if err := os.WriteFile(clayer, []byte("layer"), 0600); err != nil {
+		t.Fatalf("failed to write clayer: %v", err)
+	}
+
+	oldGetInstallConfigs := getInstallConfigs
+	t.Cleanup(func() {
+		getInstallConfigs = oldGetInstallConfigs
+	})
+
+	getInstallConfigs = func() (utils.Configurations, error) {
+		return utils.Configurations{BinPath: binDir, EtcPath: workDir, BinExtn: ""}, nil
+	}
+
+	cmd := testZephyrCmd(t, "demo", []string{clayer}, []string{defaultPack})
+	err := generateZephyrModule(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error when csolution binary is missing")
+	}
+	if !strings.Contains(err.Error(), "csolution not found") {
+		t.Fatalf("expected missing csolution binary error, got %v", err)
 	}
 }

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -134,6 +134,10 @@ func (b CSolutionBuilder) installMissingPacks() (err error) {
 	return nil
 }
 
+func (b CSolutionBuilder) InstallMissingPacks() error {
+	return b.installMissingPacks()
+}
+
 func (b CSolutionBuilder) generateBuildFiles() (err error) {
 	args := b.formulateArgs([]string{"convert"})
 

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -96,7 +96,7 @@ func (b CSolutionBuilder) runCSolution(args []string, quiet bool) (output string
 	return
 }
 
-func (b CSolutionBuilder) installMissingPacks() (err error) {
+func (b CSolutionBuilder) InstallMissingPacks() (err error) {
 	if !b.Options.Packs {
 		return nil
 	}
@@ -137,10 +137,6 @@ func (b CSolutionBuilder) installMissingPacks() (err error) {
 		}
 	}
 	return nil
-}
-
-func (b CSolutionBuilder) InstallMissingPacks() error {
-	return b.installMissingPacks()
 }
 
 func (b CSolutionBuilder) generateBuildFiles() (err error) {
@@ -646,7 +642,7 @@ func (b CSolutionBuilder) Build() (err error) {
 
 	if !b.Options.SkipConvert || !b.buildFilesExist() {
 		// STEP 1: Install missing pack(s)
-		if err = b.installMissingPacks(); err != nil {
+		if err = b.InstallMissingPacks(); err != nil {
 			// Continue with build files generation upon setup command
 			if !b.Setup {
 				log.Error(err)

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -139,6 +139,10 @@ func (b CSolutionBuilder) installMissingPacks() (err error) {
 	return nil
 }
 
+func (b CSolutionBuilder) InstallMissingPacks() error {
+	return b.installMissingPacks()
+}
+
 func (b CSolutionBuilder) generateBuildFiles() (err error) {
 	args := b.formulateArgs([]string{"convert"})
 

--- a/pkg/builder/csolution/builder_test.go
+++ b/pkg/builder/csolution/builder_test.go
@@ -349,21 +349,21 @@ func TestInstallMissingPacks(t *testing.T) {
 	}
 
 	t.Run("test install missing packs", func(t *testing.T) {
-		err := b.installMissingPacks()
+		err := b.InstallMissingPacks()
 		assert.Nil(err)
 	})
 
 	t.Run("test install missing packs with invalid path", func(t *testing.T) {
 		binExtn := b.InstallConfigs.BinExtn
 		b.InstallConfigs.BinExtn = "invalid_path"
-		err := b.installMissingPacks()
+		err := b.InstallMissingPacks()
 		b.InstallConfigs.BinExtn = binExtn
 		assert.Error(err)
 	})
 
 	t.Run("test install missing packs with no --pack arg", func(t *testing.T) {
 		b.Options.Packs = false
-		err := b.installMissingPacks()
+		err := b.InstallMissingPacks()
 		assert.Nil(err)
 	})
 }

--- a/pkg/errutils/errutils.go
+++ b/pkg/errutils/errutils.go
@@ -47,7 +47,6 @@ const (
 	ErrRelativizeClayerPath   = "unable to relativize clayer path %q against project file %q: %v"
 	ErrMissingModuleArg       = "missing required argument: --module"
 	ErrMissingClayerArg       = "missing required argument: --clayer requires at least one layer"
-	ErrOverwritingDestination = "overwriting existing destination: %s"
 )
 
 const (

--- a/pkg/errutils/errutils.go
+++ b/pkg/errutils/errutils.go
@@ -41,6 +41,13 @@ const (
 	ErrInvalidCbuildFormat    = "invalid cbuild format: '%s'"
 	ErrChildFailed            = "child process failed with exit code: '%d'"
 	ErrInvalidRootsCmake      = "invalid roots.cmake file: '%s'"
+	ErrInvalidClayerPath      = "invalid clayer path %q: %v"
+	ErrClayerAccess           = "unable to access clayer file %s: %v"
+	ErrClayerPathIsDirectory  = "clayer path is a directory: %s"
+	ErrRelativizeClayerPath   = "unable to relativize clayer path %q against project file %q: %v"
+	ErrMissingModuleArg       = "missing required argument: --module"
+	ErrMissingClayerArg       = "missing required argument: --clayer requires at least one layer"
+	ErrOverwritingDestination = "overwriting existing destination: %s"
 )
 
 const (

--- a/pkg/errutils/errutils.go
+++ b/pkg/errutils/errutils.go
@@ -41,6 +41,12 @@ const (
 	ErrInvalidCbuildFormat    = "invalid cbuild format: '%s'"
 	ErrChildFailed            = "child process failed with exit code: '%d'"
 	ErrInvalidRootsCmake      = "invalid roots.cmake file: '%s'"
+	ErrInvalidClayerPath      = "invalid clayer path %q: %v"
+	ErrClayerAccess           = "unable to access clayer file %s: %v"
+	ErrClayerPathIsDirectory  = "clayer path is a directory: %s"
+	ErrRelativizeClayerPath   = "unable to relativize clayer path %q against project file %q: %v"
+	ErrMissingModuleArg       = "missing required argument: --module"
+	ErrMissingClayerArg       = "missing required argument: --clayer requires at least one layer"
 )
 
 const (

--- a/pkg/errutils/errutils.go
+++ b/pkg/errutils/errutils.go
@@ -45,8 +45,8 @@ const (
 	ErrClayerAccess           = "unable to access clayer file %s: %v"
 	ErrClayerPathIsDirectory  = "clayer path is a directory: %s"
 	ErrRelativizeClayerPath   = "unable to relativize clayer path %q against project file %q: %v"
-	ErrMissingModuleArg       = "missing required argument: --module"
-	ErrMissingClayerArg       = "missing required argument: --clayer requires at least one layer"
+	ErrMissingModuleArg       = "--module is required"
+	ErrMissingClayerArg       = "--clayer requires at least one layer"
 )
 
 const (


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->
- https://github.com/Open-CMSIS-Pack/devtools/issues/2429

## Changes
<!-- List the changes this PR introduces -->
- Adds a new `cbuild zephyr` subcommand intended to orchestrate CMSIS tooling (`csolution`, `cpackget`, `cbuild2cmake`) to generate Zephyr module files from one or more `.clayer.yml` inputs.
- Introduces `cmd/cbuild/commands/zephyr` with module generation logic and unit tests.
- Exposes `CSolutionBuilder.InstallMissingPacks()` for use by command orchestration.
- Extends shared error strings and wires the new command into the root CLI.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
