### PR TITLE
[cbuild] Verbose mode improvements

### DIFF
--- a/cmd/cbuild/commands/list/list_contexts.go
+++ b/cmd/cbuild/commands/list/list_contexts.go
@@ -53,7 +53,7 @@ func listContexts(cmd *cobra.Command, args []string) error {
 	p := csolution.CSolutionBuilder{
 		BuilderParams: builder.BuilderParams{
 			Runner: utils.Runner{
-				IsListCmd: true,
+				PlainOutput: true,
 			},
 			Options: builder.Options{
 				SchemaChk: !noSchemaChk,

--- a/cmd/cbuild/commands/list/list_environment.go
+++ b/cmd/cbuild/commands/list/list_environment.go
@@ -27,7 +27,7 @@ func listEnvironment(cmd *cobra.Command, args []string) error {
 	p := csolution.CSolutionBuilder{
 		BuilderParams: builder.BuilderParams{
 			Runner: utils.Runner{
-				IsListCmd: true,
+				PlainOutput: true,
 			},
 			InstallConfigs: configs,
 		},

--- a/cmd/cbuild/commands/list/list_target_sets.go
+++ b/cmd/cbuild/commands/list/list_target_sets.go
@@ -56,7 +56,7 @@ func listTargetSets(cmd *cobra.Command, args []string) error {
 	p := csolution.CSolutionBuilder{
 		BuilderParams: builder.BuilderParams{
 			Runner: utils.Runner{
-				IsListCmd: true,
+				PlainOutput: true,
 			},
 			Options: builder.Options{
 				SchemaChk: !noSchemaChk,

--- a/cmd/cbuild/commands/list/list_toolchains.go
+++ b/cmd/cbuild/commands/list/list_toolchains.go
@@ -54,7 +54,7 @@ func listToolchains(cmd *cobra.Command, args []string) error {
 	p := csolution.CSolutionBuilder{
 		BuilderParams: builder.BuilderParams{
 			Runner: utils.Runner{
-				IsListCmd: true,
+				PlainOutput: true,
 			},
 			Options: builder.Options{
 				Contexts:      contexts,

--- a/cmd/cbuild/commands/root.go
+++ b/cmd/cbuild/commands/root.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025 Arm Limited. All rights reserved.
+ * Copyright (c) 2022-2026 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -196,7 +196,9 @@ func NewRootCmd() *cobra.Command {
 			}
 
 			params := builder.BuilderParams{
-				Runner:         utils.Runner{},
+				Runner: utils.Runner{
+					PlainOutput: options.Debug || options.Verbose,
+				},
 				Options:        options,
 				InputFile:      inputFile,
 				InstallConfigs: configs,

--- a/cmd/cbuild/commands/setup/setup.go
+++ b/cmd/cbuild/commands/setup/setup.go
@@ -130,7 +130,9 @@ func setUpProject(cmd *cobra.Command, args []string) error {
 	}
 
 	params := builder.BuilderParams{
-		Runner:         utils.Runner{},
+		Runner: utils.Runner{
+			PlainOutput: options.Debug || options.Verbose,
+		},
 		Options:        options,
 		InputFile:      inputFile,
 		InstallConfigs: configs,

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -82,6 +83,10 @@ func (b CSolutionBuilder) runCSolution(args []string, quiet bool) (output string
 	csolutionBin, err := b.getCSolutionPath()
 	if err != nil {
 		return
+	}
+
+	if quiet {
+		args = slices.DeleteFunc(args, func(arg string) bool { return arg == "--verbose" })
 	}
 
 	log.Debug("csolution command: csolution " + strings.Join(args, " "))

--- a/pkg/builder/csolution/builder_test.go
+++ b/pkg/builder/csolution/builder_test.go
@@ -876,7 +876,9 @@ func TestRunCSolutionQuietMode(t *testing.T) {
 
 		// Call runCSolution with quiet=true and --verbose in args
 		args := []string{"convert", "--verbose", "some-file.yml"}
-		_, _ = b.runCSolution(args, true)
+		output, err := b.runCSolution(args, true)
+		assert.Equal("", output)
+		assert.Nil(err)
 
 		// Verify --verbose was removed from captured args
 		assert.NotContains(runnerCapture.capturedArgs, "--verbose")

--- a/pkg/builder/csolution/builder_test.go
+++ b/pkg/builder/csolution/builder_test.go
@@ -59,6 +59,15 @@ func (r RunnerMock) ExecuteCommand(program string, quiet bool, args ...string) (
 	return "", nil
 }
 
+type RunnerMockWithArgCapture struct {
+	capturedArgs []string
+}
+
+func (r *RunnerMockWithArgCapture) ExecuteCommand(program string, quiet bool, args ...string) (string, error) {
+	r.capturedArgs = args
+	return "", nil
+}
+
 func TestListContexts(t *testing.T) {
 	assert := assert.New(t)
 	b := CSolutionBuilder{
@@ -845,5 +854,33 @@ func TestCleanTmpOut(t *testing.T) {
 		assert.NoFileExists(spuriousFile)
 
 		_ = os.RemoveAll(tmpDir)
+	})
+}
+
+func TestRunCSolutionQuietMode(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("Quiet mode removes verbose flag", func(t *testing.T) {
+		runnerCapture := &RunnerMockWithArgCapture{}
+		b := CSolutionBuilder{
+			BuilderParams: builder.BuilderParams{
+				Runner:    runnerCapture,
+				InputFile: filepath.Join(testRoot, testDir, "TestSolution/test.csolution.yml"),
+				InstallConfigs: utils.Configurations{
+					BinPath: configs.BinPath,
+					BinExtn: configs.BinExtn,
+					EtcPath: configs.EtcPath,
+				},
+			},
+		}
+
+		// Call runCSolution with quiet=true and --verbose in args
+		args := []string{"convert", "--verbose", "some-file.yml"}
+		_, _ = b.runCSolution(args, true)
+
+		// Verify --verbose was removed from captured args
+		assert.NotContains(runnerCapture.capturedArgs, "--verbose")
+		assert.Contains(runnerCapture.capturedArgs, "convert")
+		assert.Contains(runnerCapture.capturedArgs, "some-file.yml")
 	})
 }

--- a/pkg/utils/exec.go
+++ b/pkg/utils/exec.go
@@ -26,9 +26,9 @@ type RunnerInterface interface {
 }
 
 type Runner struct {
-	outBytes  []byte // Captures the output bytes from the executed command
-	quiet     bool   // If true, suppresses output to the standard logger
-	IsListCmd bool   // Indicates if the current command is a 'list' command
+	outBytes    []byte // Captures the output bytes from the executed command
+	quiet       bool   // If true, suppresses output to the standard logger
+	PlainOutput bool   // Indicates if a "plain output" is required instead of "interactive terminal"
 }
 
 func (r *Runner) Write(bytes []byte) (n int, err error) {
@@ -51,7 +51,7 @@ func (r Runner) ExecuteCommand(program string, quiet bool, args ...string) (stri
 	}
 
 	var err error
-	if !quiet && !r.IsListCmd && isTerminal() {
+	if !quiet && !r.PlainOutput && isTerminal() {
 		// Use pty to preserve colors and interactive output
 		ptmx, ptyErr := pty.New()
 		if ptyErr == nil {


### PR DESCRIPTION
## Changes
<!-- List the changes this PR introduces -->
- Use "plain output" instead of "interactive terminal" when running in `verbose` or `debug` modes.
- Fix the issue where `--verbose` and `--quiet` are used together when calling csolution, as they are mutually exclusive. This currently produces the error:
```
cbuild Hello.csolution.yml --verbose --target all --rebuild --active <target-set>
...
error csolution: command line options '--quiet' and '--verbose' are mutually exclusive
```
- Add/update test cases

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
