### PR TITLE
[cbuild] Improve `tmp` dir creation for zephyr module

### DIFF
--- a/cmd/cbuild/commands/zephyr/zephyr.go
+++ b/cmd/cbuild/commands/zephyr/zephyr.go
@@ -194,12 +194,8 @@ func generateZephyrModule(cmd *cobra.Command, _ []string) error {
 		validPacks = []string{defaultPack}
 	}
 
-	tmpDir := filepath.Join(originalDir, moduleName+"-tmp")
-	if err = os.RemoveAll(tmpDir); err != nil {
-		log.Error(err)
-		return err
-	}
-	if err = os.MkdirAll(tmpDir, 0700); err != nil {
+	tmpDir, err := os.MkdirTemp(filepath.Dir(originalDir), moduleName+"-tmp-*")
+	if err != nil {
 		log.Error(err)
 		return err
 	}


### PR DESCRIPTION
## Changes
<!-- List the changes this PR introduces -->
- Use safer os.MkdirTemp to create a temporary directory at the appropriate level, ensuring relative paths remain coherent with the generated module.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
