### PR TITLE
Fix: cbuild always clean-build when CMSIS_COMPILER_ROOT is set

### DIFF
--- a/pkg/builder/cbuildidx/builder.go
+++ b/pkg/builder/cbuildidx/builder.go
@@ -107,7 +107,8 @@ func (b CbuildIdxBuilder) build() error {
 		return err
 	}
 
-	_ = utils.UpdateEnvVars(vars.BinPath, &vars.EtcPath)
+	env := utils.UpdateEnvVars(vars.BinPath, vars.EtcPath)
+	vars.EtcPath = env.CompilerRoot
 
 	if len(b.Options.Contexts) == 0 && b.BuildContext == "" {
 		err = errutils.New(errutils.ErrNoContextFound)

--- a/pkg/builder/cbuildidx/builder.go
+++ b/pkg/builder/cbuildidx/builder.go
@@ -107,7 +107,7 @@ func (b CbuildIdxBuilder) build() error {
 		return err
 	}
 
-	_ = utils.UpdateEnvVars(vars.BinPath, vars.EtcPath)
+	_ = utils.UpdateEnvVars(vars.BinPath, &vars.EtcPath)
 
 	if len(b.Options.Contexts) == 0 && b.BuildContext == "" {
 		err = errutils.New(errutils.ErrNoContextFound)

--- a/pkg/builder/cproject/builder.go
+++ b/pkg/builder/cproject/builder.go
@@ -117,7 +117,8 @@ func (b CprjBuilder) build() error {
 		return err
 	}
 
-	_ = utils.UpdateEnvVars(vars.BinPath, &vars.EtcPath)
+	env := utils.UpdateEnvVars(vars.BinPath, vars.EtcPath)
+	vars.EtcPath = env.CompilerRoot
 
 	if b.Options.Rebuild {
 		err = b.clean(dirs, vars)

--- a/pkg/builder/cproject/builder.go
+++ b/pkg/builder/cproject/builder.go
@@ -117,7 +117,7 @@ func (b CprjBuilder) build() error {
 		return err
 	}
 
-	_ = utils.UpdateEnvVars(vars.BinPath, vars.EtcPath)
+	_ = utils.UpdateEnvVars(vars.BinPath, &vars.EtcPath)
 
 	if b.Options.Rebuild {
 		err = b.clean(dirs, vars)

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -638,7 +638,8 @@ func (b CSolutionBuilder) build() (err error) {
 }
 
 func (b CSolutionBuilder) Build() (err error) {
-	_ = utils.UpdateEnvVars(b.InstallConfigs.BinPath, &b.InstallConfigs.EtcPath)
+	env := utils.UpdateEnvVars(b.InstallConfigs.BinPath, b.InstallConfigs.EtcPath)
+	b.InstallConfigs.EtcPath = env.CompilerRoot
 
 	if !b.Options.SkipConvert || !b.buildFilesExist() {
 		// STEP 1: Install missing pack(s)

--- a/pkg/builder/csolution/builder.go
+++ b/pkg/builder/csolution/builder.go
@@ -638,7 +638,7 @@ func (b CSolutionBuilder) build() (err error) {
 }
 
 func (b CSolutionBuilder) Build() (err error) {
-	_ = utils.UpdateEnvVars(b.InstallConfigs.BinPath, b.InstallConfigs.EtcPath)
+	_ = utils.UpdateEnvVars(b.InstallConfigs.BinPath, &b.InstallConfigs.EtcPath)
 
 	if !b.Options.SkipConvert || !b.buildFilesExist() {
 		// STEP 1: Install missing pack(s)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -50,7 +50,7 @@ func GetExecutablePath() (string, error) {
 	return executablePath, nil
 }
 
-func UpdateEnvVars(binPath string, etcPath string) (env EnvVars) {
+func UpdateEnvVars(binPath string, etcPath *string) (env EnvVars) {
 	env.PackRoot = os.Getenv("CMSIS_PACK_ROOT")
 	if env.PackRoot == "" {
 		packRoot := GetDefaultCmsisPackRoot()
@@ -61,10 +61,12 @@ func UpdateEnvVars(binPath string, etcPath string) (env EnvVars) {
 	}
 	env.CompilerRoot = os.Getenv("CMSIS_COMPILER_ROOT")
 	if env.CompilerRoot == "" {
-		env.CompilerRoot, _ = filepath.Abs(etcPath)
+		env.CompilerRoot, _ = filepath.Abs(*etcPath)
 		os.Setenv("CMSIS_COMPILER_ROOT", env.CompilerRoot)
 	}
 	env.BuildRoot, _ = filepath.Abs(binPath)
+	*etcPath = env.CompilerRoot
+
 	log.Debug("CMSIS_PACK_ROOT: " + env.PackRoot)
 	log.Debug("CMSIS_COMPILER_ROOT: " + env.CompilerRoot)
 	return env

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -50,7 +50,7 @@ func GetExecutablePath() (string, error) {
 	return executablePath, nil
 }
 
-func UpdateEnvVars(binPath string, etcPath *string) (env EnvVars) {
+func UpdateEnvVars(binPath string, etcPath string) (env EnvVars) {
 	env.PackRoot = os.Getenv("CMSIS_PACK_ROOT")
 	if env.PackRoot == "" {
 		packRoot := GetDefaultCmsisPackRoot()
@@ -61,11 +61,10 @@ func UpdateEnvVars(binPath string, etcPath *string) (env EnvVars) {
 	}
 	env.CompilerRoot = os.Getenv("CMSIS_COMPILER_ROOT")
 	if env.CompilerRoot == "" {
-		env.CompilerRoot, _ = filepath.Abs(*etcPath)
+		env.CompilerRoot, _ = filepath.Abs(etcPath)
 		os.Setenv("CMSIS_COMPILER_ROOT", env.CompilerRoot)
 	}
 	env.BuildRoot, _ = filepath.Abs(binPath)
-	*etcPath = env.CompilerRoot
 
 	log.Debug("CMSIS_PACK_ROOT: " + env.PackRoot)
 	log.Debug("CMSIS_COMPILER_ROOT: " + env.CompilerRoot)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -41,7 +41,7 @@ func TestUpdateEnvVars(t *testing.T) {
 	t.Run("test update environment variables", func(t *testing.T) {
 		binPath := testRoot + "/bin"
 		etcPath := testRoot + "/etc"
-		env := UpdateEnvVars(binPath, etcPath)
+		env := UpdateEnvVars(binPath, &etcPath)
 		binPath, _ = filepath.Abs(binPath)
 		etcPath, _ = filepath.Abs(etcPath)
 		assert.Equal(env.BuildRoot, binPath)
@@ -54,7 +54,7 @@ func TestUpdateEnvVars(t *testing.T) {
 		etcPath := testRoot + "/etc"
 		packRoot, _ := filepath.Abs(testRoot + "/packs")
 		_ = os.Setenv("CMSIS_PACK_ROOT", packRoot)
-		env := UpdateEnvVars(binPath, etcPath)
+		env := UpdateEnvVars(binPath, &etcPath)
 		binPath, _ = filepath.Abs(binPath)
 		etcPath, _ = filepath.Abs(etcPath)
 		assert.Equal(env.BuildRoot, binPath)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -41,7 +41,7 @@ func TestUpdateEnvVars(t *testing.T) {
 	t.Run("test update environment variables", func(t *testing.T) {
 		binPath := testRoot + "/bin"
 		etcPath := testRoot + "/etc"
-		env := UpdateEnvVars(binPath, &etcPath)
+		env := UpdateEnvVars(binPath, etcPath)
 		binPath, _ = filepath.Abs(binPath)
 		etcPath, _ = filepath.Abs(etcPath)
 		assert.Equal(env.BuildRoot, binPath)
@@ -54,7 +54,7 @@ func TestUpdateEnvVars(t *testing.T) {
 		etcPath := testRoot + "/etc"
 		packRoot, _ := filepath.Abs(testRoot + "/packs")
 		_ = os.Setenv("CMSIS_PACK_ROOT", packRoot)
-		env := UpdateEnvVars(binPath, &etcPath)
+		env := UpdateEnvVars(binPath, etcPath)
 		binPath, _ = filepath.Abs(binPath)
 		etcPath, _ = filepath.Abs(etcPath)
 		assert.Equal(env.BuildRoot, binPath)


### PR DESCRIPTION
## Fixes
- https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/632

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
