### PR TITLE
Update pinned CodeQL action SHA in workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3.29.5
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v3.29.5
         with:
           languages: go
           queries: security-and-quality
@@ -56,4 +56,4 @@ jobs:
           go build ./cmd/cbuild
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3.29.5
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v3.29.5

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -71,6 +71,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3.29.5
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v3.29.5
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Fixes
- https://github.com/Open-CMSIS-Pack/cbuild/pull/651
- https://github.com/Open-CMSIS-Pack/cbuild/pull/652
- https://github.com/Open-CMSIS-Pack/cbuild/pull/653

## Changes
- Updated the pinned `github/codeql-action` commit SHA used by:
  - CodeQL initialization and analysis in `.github/workflows/codeql.yml`
  - SARIF upload in `.github/workflows/scorecard.yml`

## Risk / Limitations
- Low risk; this only changes GitHub Actions workflow references and does not affect application code.
- Follow up by monitoring the next CodeQL and Scorecard workflow runs for successful execution.

## Checklist
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).