### PR TITLE
Tune Dependabot settings for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,11 +5,19 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     rebase-strategy: disabled
-    reviewers:
-      - "soumeh01"
-      - "brondani"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 14
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
 
   - package-ecosystem: "gomod"
     directory: "/"


### PR DESCRIPTION
## Fixes
- None

## Changes
- Reduced the Dependabot open PR limit for GitHub Actions updates from 10 to 5.
- Grouped all GitHub Actions dependency updates into a single Dependabot group.
- Added a 14-day cooldown for dependency update PRs.
- Standardized Dependabot commit messages with the `ci` prefix.
- Added `dependencies` and `github-actions` labels to generated PRs.
- Removed explicit Dependabot reviewers from the configuration.

## Risk / Follow-up
- GitHub Actions updates may arrive more slowly due to the cooldown and lower PR limit.
- Reviewer assignment will rely on repository defaults or manual assignment instead of Dependabot configuration.

## Checklist
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).